### PR TITLE
website: attempt to dissuade use of consul_service

### DIFF
--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -11,6 +11,20 @@ description: |-
 A high-level resource for creating a Service in Consul. Currently,
 defining health checks for a service is not supported.
 
+**Most users should not use this resource**. When using Consul with
+compute instances, it's better to install
+[the Consul Agent](https://www.consul.io/docs/agent/basics.html)
+on these machines and register services via the agent. This ensures
+that services get assigned to the appropriate Consul "nodes" and
+allows service health to integrate with general node health as
+reported by the agent.
+
+To register a non-compute resource, such as a hosted database,
+as a service, as described in
+[Consul's _External Services_ guide](https://www.consul.io/docs/guides/external.html),
+use [`consul_catalog_entry`](catalog_entry.html) instead, which
+can create an arbitrary service record in the Consul catalog.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
The `consul_service` resource is not something most users should use, since service registration is normally done by a Consul Agent once a machine is running rather than via an external API call during provisioning.

The name of this resource makes it a bit of an attractive nuisance for those intending instead to register [External Services](https://www.consul.io/docs/guides/external.html). For that, the `consul_catalog_entry` resource is the right approach since it allows creation of a service entry that isn't associated with a "real" node.