### PR TITLE
Fix consul_keys deprecation warning.

### DIFF
--- a/examples/kv/main.tf
+++ b/examples/kv/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 }
 
 # Setup a key in Consul to provide inputs
-resource "consul_keys" "input" {
+data "consul_keys" "input" {
   key {
     name    = "size"
     path    = "tf_test/size"
@@ -22,7 +22,7 @@ resource "consul_keys" "input" {
 # instance type
 resource "aws_instance" "test" {
   ami           = "${lookup(var.aws_amis, var.aws_region)}"
-  instance_type = "${consul_keys.input.var.size}"
+  instance_type = "${data.consul_keys.input.var.size}"
 }
 
 # Setup a key in Consul to store the instance id and


### PR DESCRIPTION
This example reads a key using a `consul_keys` `resource,` which produces the warning:
```
* consul_keys.input: "key.0.name": [DEPRECATED] Using consul_keys resource to *read* is deprecated; please use consul_keys data source instead
```

Switching to the `consul_keys` `data` source fixes it (though not the other two erroneous
warnings caused by consul_keys being used to write)