### PR TITLE
d/consul_agent_self: Fix double underscore in title (doc)

### DIFF
--- a/website/docs/d/agent_self.html.markdown
+++ b/website/docs/d/agent_self.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides the configuration information of the local Consul agent.
 ---
 
-# consul_agent__self
+# consul_agent_self
 
 The `consul_agent_self` data source returns
 [configuration and status data](https://www.consul.io/docs/agent/http/agent.html#agent_self)


### PR DESCRIPTION
This PR removes a double underscore in the title for the `consul_agent_self`  data source.