### PR TITLE
Add insecure option as requested in GH-6

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -1,6 +1,7 @@
 package consul
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -9,15 +10,15 @@ import (
 )
 
 type Config struct {
-	Datacenter string `mapstructure:"datacenter"`
-	Address    string `mapstructure:"address"`
-	Scheme     string `mapstructure:"scheme"`
-	HttpAuth   string `mapstructure:"http_auth"`
-	Token      string `mapstructure:"token"`
-	CAFile     string `mapstructure:"ca_file"`
-	CertFile   string `mapstructure:"cert_file"`
-	KeyFile    string `mapstructure:"key_file"`
-	Insecure   bool   `mapstructure:"insecure"`
+	Datacenter    string `mapstructure:"datacenter"`
+	Address       string `mapstructure:"address"`
+	Scheme        string `mapstructure:"scheme"`
+	HttpAuth      string `mapstructure:"http_auth"`
+	Token         string `mapstructure:"token"`
+	CAFile        string `mapstructure:"ca_file"`
+	CertFile      string `mapstructure:"cert_file"`
+	KeyFile       string `mapstructure:"key_file"`
+	InsecureHttps bool   `mapstructure:"insecure_https"`
 }
 
 // Client() returns a new client for accessing consul.
@@ -38,8 +39,11 @@ func (c *Config) Client() (*consulapi.Client, error) {
 	tlsConfig.CAFile = c.CAFile
 	tlsConfig.CertFile = c.CertFile
 	tlsConfig.KeyFile = c.KeyFile
-	if c.Insecure {
-		tlsConfig.InsecureSkipVerify = c.Insecure
+	if c.InsecureHttps {
+		if config.Scheme != "https" {
+			return nil, fmt.Errorf("insecure_https is meant to be used when scheme is https")
+		}
+		tlsConfig.InsecureSkipVerify = c.InsecureHttps
 	}
 	cc, err := consulapi.SetupTLSConfig(tlsConfig)
 	if err != nil {
@@ -66,7 +70,7 @@ func (c *Config) Client() (*consulapi.Client, error) {
 	client, err := consulapi.NewClient(config)
 
 	log.Printf("[INFO] Consul Client configured with address: '%s', scheme: '%s', datacenter: '%s'"+
-		", insecure: '%t'", config.Address, config.Scheme, config.Datacenter, tlsConfig.InsecureSkipVerify)
+		", insecure_https: '%t'", config.Address, config.Scheme, config.Datacenter, tlsConfig.InsecureSkipVerify)
 	if err != nil {
 		return nil, err
 	}

--- a/consul/config.go
+++ b/consul/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	CAFile     string `mapstructure:"ca_file"`
 	CertFile   string `mapstructure:"cert_file"`
 	KeyFile    string `mapstructure:"key_file"`
+	Insecure   bool   `mapstructure:"insecure"`
 }
 
 // Client() returns a new client for accessing consul.
@@ -37,6 +38,9 @@ func (c *Config) Client() (*consulapi.Client, error) {
 	tlsConfig.CAFile = c.CAFile
 	tlsConfig.CertFile = c.CertFile
 	tlsConfig.KeyFile = c.KeyFile
+	if c.Insecure {
+		tlsConfig.InsecureSkipVerify = c.Insecure
+	}
 	cc, err := consulapi.SetupTLSConfig(tlsConfig)
 	if err != nil {
 		return nil, err
@@ -61,8 +65,8 @@ func (c *Config) Client() (*consulapi.Client, error) {
 
 	client, err := consulapi.NewClient(config)
 
-	log.Printf("[INFO] Consul Client configured with address: '%s', scheme: '%s', datacenter: '%s'",
-		config.Address, config.Scheme, config.Datacenter)
+	log.Printf("[INFO] Consul Client configured with address: '%s', scheme: '%s', datacenter: '%s'"+
+		", insecure: '%t'", config.Address, config.Scheme, config.Datacenter, tlsConfig.InsecureSkipVerify)
 	if err != nil {
 		return nil, err
 	}

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -59,7 +59,7 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("CONSUL_KEY_FILE", ""),
 			},
 
-			"insecure": &schema.Schema{
+			"insecure_https": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -59,6 +59,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("CONSUL_KEY_FILE", ""),
 			},
 
+			"insecure": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"token": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,

--- a/consul/resource_provider_test.go
+++ b/consul/resource_provider_test.go
@@ -72,6 +72,27 @@ func TestResourceProvider_ConfigureTLS(t *testing.T) {
 	}
 }
 
+func TestResourceProvider_ConfigureTLSInsecure(t *testing.T) {
+	rp := Provider()
+
+	raw := map[string]interface{}{
+		"address":    "demo.consul.io:80",
+		"datacenter": "nyc3",
+		"scheme":     "https",
+		"insecure":   true,
+	}
+
+	rawConfig, err := config.NewRawConfig(raw)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = rp.Configure(terraform.NewResourceConfig(rawConfig))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("CONSUL_HTTP_ADDR"); v != "" {
 		return

--- a/consul/resource_provider_test.go
+++ b/consul/resource_provider_test.go
@@ -72,14 +72,14 @@ func TestResourceProvider_ConfigureTLS(t *testing.T) {
 	}
 }
 
-func TestResourceProvider_ConfigureTLSInsecure(t *testing.T) {
+func TestResourceProvider_ConfigureTLSInsecureHttps(t *testing.T) {
 	rp := Provider()
 
 	raw := map[string]interface{}{
-		"address":    "demo.consul.io:80",
-		"datacenter": "nyc3",
-		"scheme":     "https",
-		"insecure":   true,
+		"address":        "demo.consul.io:80",
+		"datacenter":     "nyc3",
+		"scheme":         "https",
+		"insecure_https": true,
 	}
 
 	rawConfig, err := config.NewRawConfig(raw)
@@ -90,6 +90,27 @@ func TestResourceProvider_ConfigureTLSInsecure(t *testing.T) {
 	err = rp.Configure(terraform.NewResourceConfig(rawConfig))
 	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestResourceProvider_ConfigureTLSInsecureHttpsMismatch(t *testing.T) {
+	rp := Provider()
+
+	raw := map[string]interface{}{
+		"address":        "demo.consul.io:80",
+		"datacenter":     "nyc3",
+		"scheme":         "http",
+		"insecure_https": true,
+	}
+
+	rawConfig, err := config.NewRawConfig(raw)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = rp.Configure(terraform.NewResourceConfig(rawConfig))
+	if err == nil {
+		t.Fatal("Provider should error if insecure_https is set but scheme is not https")
 	}
 }
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -51,4 +51,4 @@ The following arguments are supported:
 * `ca_file` - (Optional) A path to a PEM-encoded certificate authority used to verify the remote agent's certificate.
 * `cert_file` - (Optional) A path to a PEM-encoded certificate provided to the remote agent; requires use of `key_file`.
 * `key_file`- (Optional) A path to a PEM-encoded private key, required if `cert_file` is specified.
-* `insecure`- (Optional) Boolean value to disable SSL certificate verification; setting this value to true is not recommended for production use.
+* `insecure_https`- (Optional) Boolean value to disable SSL certificate verification; setting this value to true is not recommended for production use.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -51,3 +51,4 @@ The following arguments are supported:
 * `ca_file` - (Optional) A path to a PEM-encoded certificate authority used to verify the remote agent's certificate.
 * `cert_file` - (Optional) A path to a PEM-encoded certificate provided to the remote agent; requires use of `key_file`.
 * `key_file`- (Optional) A path to a PEM-encoded private key, required if `cert_file` is specified.
+* `insecure`- (Optional) Boolean value to disable SSL certificate verification; setting this value to true is not recommended for production use.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -51,4 +51,4 @@ The following arguments are supported:
 * `ca_file` - (Optional) A path to a PEM-encoded certificate authority used to verify the remote agent's certificate.
 * `cert_file` - (Optional) A path to a PEM-encoded certificate provided to the remote agent; requires use of `key_file`.
 * `key_file`- (Optional) A path to a PEM-encoded private key, required if `cert_file` is specified.
-* `insecure_https`- (Optional) Boolean value to disable SSL certificate verification; setting this value to true is not recommended for production use.
+* `insecure_https`- (Optional) Boolean value to disable SSL certificate verification; setting this value to true is not recommended for production use. Only use this with scheme set to "https".


### PR DESCRIPTION
#6 

This adds the insecure option.  I used `insecure` instead of `ssl_verify` because I saw the same option in OpenStack provider so thought it would be more acceptable.  https://github.com/terraform-providers/terraform-provider-openstack/blob/master/openstack/config.go#L28

I haven't been able to do a real world test against an insecure endpoint.  I might be able to do that tomorrow.

```bash
$ make testacc TESTARGS='-run=TestResourceProvider'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestResourceProvider -timeout 120m
?   	github.com/terraform-providers/terraform-provider-consul	[no test files]
=== RUN   TestResourceProvider
--- PASS: TestResourceProvider (0.00s)
=== RUN   TestResourceProvider_impl
--- PASS: TestResourceProvider_impl (0.00s)
=== RUN   TestResourceProvider_Configure
2017/12/26 21:52:13 [INFO] Initializing Consul client
2017/12/26 21:52:13 [INFO] Consul Client configured with address: 'demo.consul.io:80', scheme: 'https', datacenter: 'nyc3', insecure: 'false'
--- PASS: TestResourceProvider_Configure (0.00s)
=== RUN   TestResourceProvider_ConfigureTLS
2017/12/26 21:52:13 [INFO] Initializing Consul client
2017/12/26 21:52:13 [INFO] Consul Client configured with address: 'demo.consul.io:80', scheme: 'https', datacenter: 'nyc3', insecure: 'false'
--- PASS: TestResourceProvider_ConfigureTLS (0.00s)
=== RUN   TestResourceProvider_ConfigureTLSInsecure
2017/12/26 21:52:13 [INFO] Initializing Consul client
2017/12/26 21:52:13 [INFO] Consul Client configured with address: 'demo.consul.io:80', scheme: 'https', datacenter: 'nyc3', insecure: 'true'
--- PASS: TestResourceProvider_ConfigureTLSInsecure (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-consul/consul	0.020s
```