### PR TITLE
GH-29: Make tag and datacenter optional to allow them to be used

### DIFF
--- a/consul/data_source_consul_catalog_service.go
+++ b/consul/data_source_consul_catalog_service.go
@@ -40,14 +40,14 @@ func dataSourceConsulCatalogService() *schema.Resource {
 			catalogServiceDatacenter: &schema.Schema{
 				// Used in the query, must be stored and force a refresh if the value
 				// changes.
-				Computed: true,
+				Optional: true,
 				Type:     schema.TypeString,
 				ForceNew: true,
 			},
 			catalogServiceTag: &schema.Schema{
 				// Used in the query, must be stored and force a refresh if the value
 				// changes.
-				Computed: true,
+				Optional: true,
 				Type:     schema.TypeString,
 				ForceNew: true,
 			},

--- a/consul/data_source_consul_catalog_service_test.go
+++ b/consul/data_source_consul_catalog_service_test.go
@@ -35,6 +35,31 @@ func TestAccDataConsulCatalogService_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataConsulCatalogService_filtered(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataConsulCatalogServiceFilteredConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceValue("data.consul_catalog_service.read_f", "datacenter", "dc1"),
+					testAccCheckDataSourceValue("data.consul_catalog_service.read_f", "service.#", "1"),
+					testAccCheckDataSourceValue("data.consul_catalog_service.read_f", "service.0.address", "192.168.10.10"),
+					testAccCheckDataSourceValue("data.consul_catalog_service.read_f", "service.0.create_index", "<any>"),
+					testAccCheckDataSourceValue("data.consul_catalog_service.read_f", "service.0.enable_tag_override", "<any>"),
+					testAccCheckDataSourceValue("data.consul_catalog_service.read_f", "service.0.id", "redis1"),
+					testAccCheckDataSourceValue("data.consul_catalog_service.read_f", "service.0.modify_index", "<any>"),
+					testAccCheckDataSourceValue("data.consul_catalog_service.read_f", "service.0.name", "redis"),
+					testAccCheckDataSourceValue("data.consul_catalog_service.read_f", "service.0.node_name", "foobar"),
+					testAccCheckDataSourceValue("data.consul_catalog_service.read_f", "service.0.port", "<any>"),
+					testAccCheckDataSourceValue("data.consul_catalog_service.read_f", "service.0.tags.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 const testAccDataConsulCatalogServiceConfig = `
 data "consul_catalog_service" "read" {
   query_options {
@@ -46,5 +71,47 @@ data "consul_catalog_service" "read" {
   }
 
   name = "consul"
+}
+`
+
+const testAccDataConsulCatalogServiceFilteredConfig = `
+resource "consul_catalog_entry" "service1" {
+  address = "192.168.10.11"
+  node    = "foobar_dummy"
+  datacenter = "dc1"
+
+  service = {
+    id      = "redis2"
+    name    = "redis"
+    port    = 8000
+    tags    = ["v1"]
+  }
+}
+
+resource "consul_catalog_entry" "service2" {
+  address = "192.168.10.10"
+  node    = "foobar"
+  datacenter = "${consul_catalog_entry.service1.datacenter}"
+
+  service = {
+    id      = "redis1"
+    name    = "redis"
+    port    = 8000
+    tags    = ["master", "v1"]
+  }
+}
+
+data "consul_catalog_service" "read_f" {
+  query_options {
+    allow_stale = true
+    require_consistent = false
+    token = ""
+    wait_index = 0
+    wait_time = "1m"
+  }
+
+  name = "redis"
+  tag = "master"
+  datacenter = "${consul_catalog_entry.service2.datacenter}"
 }
 `


### PR DESCRIPTION
GH-29

I was able to reproduce the issue reported in GH-29 simply by adding a test case.  The solution proposed to make these optional instead of computed made things work.

I created a separate test function because the basic doesn't necessarily work out of the box and I didn't want to expand the scope of this easy fix.

```bash
$ make testacc TESTARGS='-run=TestAccDataConsulCatalogService_filtered'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDataConsulCatalogService_filtered -timeout 120m
?   	github.com/terraform-providers/terraform-provider-consul	[no test files]
=== RUN   TestAccDataConsulCatalogService_filtered
--- PASS: TestAccDataConsulCatalogService_filtered (0.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-consul/consul	0.124s
```