### PR TITLE
GH-23: Handle missing service

### DIFF
--- a/consul/resource_consul_service.go
+++ b/consul/resource_consul_service.go
@@ -2,6 +2,7 @@ package consul
 
 import (
 	"fmt"
+	"log"
 
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -120,7 +121,9 @@ func resourceConsulServiceRead(d *schema.ResourceData, meta interface{}) error {
 	if services, err := agent.Services(); err != nil {
 		return fmt.Errorf("Failed to get services from Consul agent: %v", err)
 	} else if service, ok := services[identifier]; !ok {
-		return fmt.Errorf("Failed to get service '%s' from Consul agent", identifier)
+		log.Printf("[WARN] Service not found in Consul, removing from state: %s", identifier)
+		d.SetId("")
+		return nil
 	} else {
 		d.SetId(service.ID)
 

--- a/consul/test-fixtures/docker/docker-compose.yml
+++ b/consul/test-fixtures/docker/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3"
+services:
+  consul:
+    image: consul:latest
+    environment:
+      CONSUL_LOCAL_CONFIG: "{disable_update_check: true}"
+      CONSUL_BIND_INTERFACE: eth0
+    entrypoint:
+      - consul
+      - agent
+      - -server
+      - -bootstrap-expect=1
+      - -config-dir=/consul/config
+      - -data-dir=/tmp/consul/data
+      - -bind={{ GetInterfaceIP "eth0" }}
+      - -client=0.0.0.0
+      - -ui
+      - -raft-protocol=3
+    ports:
+      - "8300:8300"
+      - "8400:8400"
+      - "8500:8500"
+      - "8600:8600/udp"
+    volumes:
+      - ./config:/consul/config


### PR DESCRIPTION
GH-23

I used aws_eip handling of not finding an EIP it thinks it should have based on state file.  https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_eip.go#L170-L172

Basically, ignore the missing service and the plan/apply will recreate.  Refresh will remove it from the tfstate as a side effect.  I believe this is all expected behavior for this scenario.

How I did real-world testing:

```hcl
resource "consul_service" "google" {
  address = "www.google.com"
  name    = "google"
  port    = 80
  tags    = ["tag0", "tag1"]
}
```

```bash
mkdir -p test-tf/plugins
make build
cp ../../../../bin/terraform-provider-consul test-tf/plugins/
cd test-tf
terraform init -plugin-dir plugins
terraform apply
curl http://localhost:8500/v1/agent/services
# it exists so remove it
curl -X PUT http://localhost:8500/v1/agent/service/deregister/google
terraform plan
# doesn't fail, plans to create
```

Added test case that removes the service out-of-band and expects a non-empty plan at the end.
```bash
$ make testacc TESTARGS='-run=TestAccConsulService'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccConsulService -timeout 120m
?   	github.com/terraform-providers/terraform-provider-consul	[no test files]
=== RUN   TestAccConsulService_basic
--- PASS: TestAccConsulService_basic (0.08s)
=== RUN   TestAccConsulService_extremove
--- PASS: TestAccConsulService_extremove (0.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-consul/consul	0.179s
```