### PR TITLE
Docs: Add note about differences between provider and backend

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -15,6 +15,14 @@ defaults for all arguments.
 
 Use the navigation to the left to read about the available resources.
 
+~> **NOTE:** The Consul provider should not be confused with the [Consul remote
+state backend][consul-remote-state-backend], which is one of many backends that
+can be used to store Terraform state. The Consul provider is instead used to
+manage resources within Consul itself, such as adding external services or
+working with the key/value store.
+
+[consul-remote-state-backend]: /docs/backends/types/consul.html
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Should help differentiate between what the remote state backend is used
for and when it's used, versus the provider and when it should be used.

Fixes #22.