### PR TITLE
New data source: consul_agent_config

### DIFF
--- a/consul/data_source_consul_agent_config.go
+++ b/consul/data_source_consul_agent_config.go
@@ -1,0 +1,78 @@
+package consul
+
+import (
+	"fmt"
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceConsulAgentConfig() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceConsulAgentConfigRead,
+
+		Schema: map[string]*schema.Schema{
+			"datacenter": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The datacenter the agent is running in",
+				Computed:    true,
+			},
+
+			"node_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The ID of the node the agent is running on",
+				Computed:    true,
+			},
+
+			"node_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The name of the node the agent is running on",
+				Computed:    true,
+			},
+
+			"server": &schema.Schema{
+				Type:        schema.TypeBool,
+				Description: "If the agent is a server or not",
+				Computed:    true,
+			},
+
+			"revision": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The VCS revision of the build of Consul that is running",
+				Computed:    true,
+			},
+
+			"version": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The version of the build of Consul that is running",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceConsulAgentConfigRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*consulapi.Client)
+	agentSelf, err := client.Agent().Self()
+	if err != nil {
+		return err
+	}
+
+	config, ok := agentSelf["Config"]
+	if !ok {
+		return fmt.Errorf("Config key not present on agent self endpoint")
+	}
+
+	// We use the ID of the node as the datasource ID, as the datasource
+	// queries config from the agent running on that registered node, so it
+	// is the best we can do to get a consistent identifier
+	d.SetId(fmt.Sprintf("agent-%s", config["NodeId"]))
+
+	d.Set("datacenter", config["Datacenter"])
+	d.Set("node_id", config["NodeID"])
+	d.Set("node_name", config["NodeName"])
+	d.Set("server", config["Server"])
+	d.Set("revision", config["Revision"])
+	d.Set("version", config["Version"])
+
+	return nil
+}

--- a/consul/data_source_consul_agent_config_test.go
+++ b/consul/data_source_consul_agent_config_test.go
@@ -1,0 +1,31 @@
+package consul
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataConsulAgentConfig_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataConsulAgentConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.consul_agent_config.example", "datacenter", "dc1"),
+					resource.TestCheckResourceAttr("data.consul_agent_config.example", "server", "true"),
+					resource.TestCheckResourceAttrSet("data.consul_agent_config.example", "node_name"),
+					resource.TestCheckResourceAttrSet("data.consul_agent_config.example", "node_id"),
+					resource.TestCheckResourceAttrSet("data.consul_agent_config.example", "revision"),
+					resource.TestCheckResourceAttrSet("data.consul_agent_config.example", "version"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataConsulAgentConfig = `
+data "consul_agent_config" "example" {}
+`

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -77,6 +77,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"consul_agent_self":       dataSourceConsulAgentSelf(),
+			"consul_agent_config":     dataSourceConsulAgentConfig(),
 			"consul_catalog_nodes":    dataSourceConsulCatalogNodes(),
 			"consul_catalog_service":  dataSourceConsulCatalogService(),
 			"consul_catalog_services": dataSourceConsulCatalogServices(),

--- a/website/consul.erb
+++ b/website/consul.erb
@@ -3,63 +3,77 @@
     <div class="docs-sidebar hidden-print affix-top" role="complementary">
       <ul class="nav docs-sidenav">
         <li<%= sidebar_current("docs-home") %>>
-        <a href="/docs/providers/index.html">All Providers</a>
-                </li>
+          <a href="/docs/providers/index.html">All Providers</a>
+        </li>
 
         <li<%= sidebar_current("docs-consul-index") %>>
-        <a href="/docs/providers/consul/index.html">Consul Provider</a>
-                </li>
+          <a href="/docs/providers/consul/index.html">Consul Provider</a>
+        </li>
 
         <li<%= sidebar_current("docs-consul-data-source") %>>
-        <a href="#">Data Sources</a>
-                <ul class="nav nav-visible">
-                  <li<%= sidebar_current("docs-consul-data-source-agent-self") %>>
-        <a href="/docs/providers/consul/d/agent_self.html">consul_agent_self</a>
-      </li>
-                  <li<%= sidebar_current("docs-consul-data-source-catalog-nodes") %>>
-        <a href="/docs/providers/consul/d/nodes.html">consul_catalog_nodes</a>
-      </li>
-                  <li<%= sidebar_current("docs-consul-data-source-catalog-service") %>>
-        <a href="/docs/providers/consul/d/service.html">consul_catalog_service</a>
-      </li>
-                  <li<%= sidebar_current("docs-consul-data-source-catalog-services") %>>
-        <a href="/docs/providers/consul/d/services.html">consul_catalog_services</a>
-      </li>
-                  <li<%= sidebar_current("docs-consul-data-source-keys") %>>
-        <a href="/docs/providers/consul/d/keys.html">consul_keys</a>
-      </li>
-                  <li<%= sidebar_current("docs-consul-data-source-key-prefix") %>>
-        <a href="/docs/providers/consul/d/key_prefix.html">consul_key_prefix</a>
-      </li>
-    </ul>
-        </li>
+          <a href="#">Data Sources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-consul-data-source-agent-self") %>>
+              <a href="/docs/providers/consul/d/agent_self.html">consul_agent_self</a>
+            </li>
 
-        <li<%= sidebar_current("docs-consul-resource") %>>
-        <a href="#">Resources</a>
-                <ul class="nav nav-visible">
-                  <li<%= sidebar_current("docs-consul-resource-agent-service") %>>
-                    <a href="/docs/providers/consul/r/agent_service.html">consul_agent_service</a>
-                  </li>
-                  <li<%= sidebar_current("docs-consul-resource-catalog-entry") %>>
-                    <a href="/docs/providers/consul/r/catalog_entry.html">consul_catalog_entry</a>
-                  </li>
-                    <li<%= sidebar_current("docs-consul-resource-keys") %>>
-          <a href="/docs/providers/consul/r/keys.html">consul_keys</a>
-          </li>
-                    <li<%= sidebar_current("docs-consul-resource-key-prefix") %>>
-          <a href="/docs/providers/consul/r/key_prefix.html">consul_key_prefix</a>
-          </li>
-                  <li<%= sidebar_current("docs-consul-resource-node") %>>
-                    <a href="/docs/providers/consul/r/node.html">consul_node</a>
-                  </li>
-                  <li<%= sidebar_current("docs-consul-resource-prepared-query") %>>
-        <a href="/docs/providers/consul/r/prepared_query.html">consul_prepared_query</a>
-        </li>
-                  <li<%= sidebar_current("docs-consul-resource-service") %>>
-                    <a href="/docs/providers/consul/r/service.html">consul_service</a>
-                  </li>
+            <li<%= sidebar_current("docs-consul-data-source-agent-config") %>>
+              <a href="/docs/providers/consul/d/agent_config.html">consul_agent_config</a>
+            </li>
 
+            <li<%= sidebar_current("docs-consul-data-source-catalog-nodes") %>>
+              <a href="/docs/providers/consul/d/nodes.html">consul_catalog_nodes</a>
+            </li>
+
+            <li<%= sidebar_current("docs-consul-data-source-catalog-service") %>>
+              <a href="/docs/providers/consul/d/service.html">consul_catalog_service</a>
+            </li>
+
+            <li<%= sidebar_current("docs-consul-data-source-catalog-services") %>>
+              <a href="/docs/providers/consul/d/services.html">consul_catalog_services</a>
+            </li>
+
+            <li<%= sidebar_current("docs-consul-data-source-keys") %>>
+              <a href="/docs/providers/consul/d/keys.html">consul_keys</a>
+            </li>
+
+            <li<%= sidebar_current("docs-consul-data-source-key-prefix") %>>
+              <a href="/docs/providers/consul/d/key_prefix.html">consul_key_prefix</a>
+            </li>
         </ul>
+      </li>
+
+      <li<%= sidebar_current("docs-consul-resource") %>>
+      <a href="#">Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-consul-resource-agent-service") %>>
+              <a href="/docs/providers/consul/r/agent_service.html">consul_agent_service</a>
+            </li>
+
+            <li<%= sidebar_current("docs-consul-resource-catalog-entry") %>>
+              <a href="/docs/providers/consul/r/catalog_entry.html">consul_catalog_entry</a>
+            </li>
+
+            <li<%= sidebar_current("docs-consul-resource-keys") %>>
+              <a href="/docs/providers/consul/r/keys.html">consul_keys</a>
+            </li>
+
+            <li<%= sidebar_current("docs-consul-resource-key-prefix") %>>
+              <a href="/docs/providers/consul/r/key_prefix.html">consul_key_prefix</a>
+            </li>
+
+            <li<%= sidebar_current("docs-consul-resource-node") %>>
+              <a href="/docs/providers/consul/r/node.html">consul_node</a>
+            </li>
+
+            <li<%= sidebar_current("docs-consul-resource-prepared-query") %>>
+              <a href="/docs/providers/consul/r/prepared_query.html">consul_prepared_query</a>
+            </li>
+
+            <li<%= sidebar_current("docs-consul-resource-service") %>>
+              <a href="/docs/providers/consul/r/service.html">consul_service</a>
+            </li>
+          </ul>
         </li>
       </ul>
     </div>

--- a/website/docs/d/agent_config.html.markdown
+++ b/website/docs/d/agent_config.html.markdown
@@ -8,6 +8,10 @@ description: |-
 
 # consul_agent_config
 
+~> **Note:** The `consul_agent_config` resource differs from `consul_agent_self`,
+providing less information but utilizing stable APIs. `consul_agent_self` will be
+deprecated in a future release.
+
 The `consul_agent_config` data source returns
 [configuration and status data](https://www.consul.io/docs/agent/http/agent.html#agent_self)
 from the agent specified in the `provider`.

--- a/website/docs/d/agent_config.html.markdown
+++ b/website/docs/d/agent_config.html.markdown
@@ -1,0 +1,34 @@
+---
+layout: "consul"
+page_title: "Consul: consul_agent_config"
+sidebar_current: "docs-consul-data-source-agent-config"
+description: |-
+  Provides the configuration information of the local Consul agent.
+---
+
+# consul_agent_config
+
+The `consul_agent_config` data source returns
+[configuration and status data](https://www.consul.io/docs/agent/http/agent.html#agent_self)
+from the agent specified in the `provider`.
+
+## Example Usage
+
+```hcl
+data "consul_agent_config" "remote_agent" {}
+
+output "info" {
+  consul_version = "${data.consul_agent_config.version}"
+}
+```
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `datacenter` - The datacenter the agent is running in
+* `node_id` - The ID of the node the agent is running on
+* `node_name` - The name of the node the agent is running on
+* `server` - Boolean if the agent is a server or not
+* `revision` - The first 9 characters of the VCS revision of the build of Consul that is running
+* `version` - The version of the build of Consul that is running


### PR DESCRIPTION
While attempting to get this providers acceptance tests passing on the latest version of Consul I noticed that the `consul_agent_self` data source largely did not work due to API changes in Consul.

This new datasource provides information similar to `consul_agent_self`, but is designed to only expose configuration that Consul will not change without versioning upstream.

In the 1.0 release of Consul, the [`/v1/agent/self`](https://www.consul.io/api/agent.html#read-configuration) endpoint was [modified](https://www.consul.io/docs/upgrade-specific.html#config-section-of-agent-self-endpoint-has-changed) to only expose specific config information, rather than internal Consul data structures that were subject to change without warning.

This internal structure is still available on that API, but I don't think the Terraform provider should expose it given it is explicitly not part of the Consul compatibility promise. The acceptance tests currently fail with >1.0 of Consul, and had other issues in the 0.9 series.

So, this datasource would become the preferred way of retrieving configuration and the current [`consul_agent_self`](https://www.terraform.io/docs/providers/consul/d/agent_self.html) datasource would be deprecated and removed in a future release.

The new resource exposes far fewer attributes, but I don't believe that will have major impact ( 
to users of this provider given the seemingly uncommon use case of querying the `/v1/agent/self` endpoint from where Terraform is running).

So to summarize:

- This new datasource relies on "agent/self" APIs that should not change
- The previous datasource relied on APIs that regularly changed and Consul users are now discouraged from utilizing

```
$ TESTARGS='-run TestAccDataConsulAgentConfig' CONSUL_HTTP_ADDR=localhost:8500 make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDataConsulAgentConfig -timeout 120m
?   	github.com/terraform-providers/terraform-provider-consul	[no test files]
=== RUN   TestAccDataConsulAgentConfig_basic
--- PASS: TestAccDataConsulAgentConfig_basic (0.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-consul/consul	0.069s
```

I'm not sure the process for deprecating an entire resource, but appreciate pointers there, including how I should version the provider.