### PR TITLE
Update Travis to new version of Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 language: go
 go:
-- 1.8.1
+- "1.10.3"
 
 install:
 # This script is used by the Travis build to install a cookie for


### PR DESCRIPTION
A PR is using the `t.Helper()` function, and the version of Go Travis is running with is so outdated, that doesn't exist. This updates Travis to the latest version of Go.