### PR TITLE
Fix example code in consul_key_prefix doc

### DIFF
--- a/website/docs/d/key_prefix.html.markdown
+++ b/website/docs/d/key_prefix.html.markdown
@@ -49,7 +49,7 @@ data "consul_key_prefix" "web" {
 
 # Start our instance with the dynamic ami value
 resource "aws_instance" "web" {
-  ami = "${data.consul_key_prefix.web["app/launch_ami"]}"
+  ami = "${data.consul_key_prefix.web.subkeys["app/launch_ami"]}"
 
   # ...
 }


### PR DESCRIPTION
Example is missing the `subkeys` attribute.