### PR TITLE
Add node-meta

### DIFF
--- a/consul/resource_consul_node.go
+++ b/consul/resource_consul_node.go
@@ -34,6 +34,12 @@ func resourceConsulNode() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"nodemeta": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"token": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -67,10 +73,20 @@ func resourceConsulNodeCreate(d *schema.ResourceData, meta interface{}) error {
 	address := d.Get("address").(string)
 	name := d.Get("name").(string)
 
+	nodemeta := make(map[string]string)
+	if v, ok := d.GetOk("nodemeta"); ok {
+		for k, j := range v.(map[string]interface{}) {
+			nodemeta[k] = j.(string)
+		}
+	} else {
+		nodemeta = nil
+	}
+
 	registration := &consulapi.CatalogRegistration{
 		Address:    address,
 		Datacenter: dc,
 		Node:       name,
+		NodeMeta:   nodemeta,
 	}
 
 	if _, err := catalog.Register(registration, &wOpts); err != nil {

--- a/consul/resource_consul_node.go
+++ b/consul/resource_consul_node.go
@@ -73,20 +73,18 @@ func resourceConsulNodeCreate(d *schema.ResourceData, meta interface{}) error {
 	address := d.Get("address").(string)
 	name := d.Get("name").(string)
 
-	nodeMeta := make(map[string]string)
-	if v, ok := d.GetOk("node_meta"); ok {
-		for k, j := range v.(map[string]interface{}) {
-			nodeMeta[k] = j.(string)
-		}
-	} else {
-		nodeMeta = nil
-	}
-
 	registration := &consulapi.CatalogRegistration{
 		Address:    address,
 		Datacenter: dc,
 		Node:       name,
-		NodeMeta:   nodeMeta,
+	}
+
+	if v, ok := d.GetOk("node_meta"); ok {
+		nodeMeta := make(map[string]string)
+		for k, j := range v.(map[string]interface{}) {
+			nodeMeta[k] = j.(string)
+		}
+		registration.NodeMeta = nodeMeta
 	}
 
 	if _, err := catalog.Register(registration, &wOpts); err != nil {

--- a/consul/resource_consul_node.go
+++ b/consul/resource_consul_node.go
@@ -34,7 +34,7 @@ func resourceConsulNode() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"nodemeta": &schema.Schema{
+			"node_meta": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
@@ -73,20 +73,20 @@ func resourceConsulNodeCreate(d *schema.ResourceData, meta interface{}) error {
 	address := d.Get("address").(string)
 	name := d.Get("name").(string)
 
-	nodemeta := make(map[string]string)
-	if v, ok := d.GetOk("nodemeta"); ok {
+	nodeMeta := make(map[string]string)
+	if v, ok := d.GetOk("node_meta"); ok {
 		for k, j := range v.(map[string]interface{}) {
-			nodemeta[k] = j.(string)
+			nodeMeta[k] = j.(string)
 		}
 	} else {
-		nodemeta = nil
+		nodeMeta = nil
 	}
 
 	registration := &consulapi.CatalogRegistration{
 		Address:    address,
 		Datacenter: dc,
 		Node:       name,
-		NodeMeta:   nodemeta,
+		NodeMeta:   nodeMeta,
 	}
 
 	if _, err := catalog.Register(registration, &wOpts); err != nil {

--- a/consul/resource_consul_node.go
+++ b/consul/resource_consul_node.go
@@ -34,7 +34,7 @@ func resourceConsulNode() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"node_meta": &schema.Schema{
+			"meta": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: false,
@@ -79,7 +79,7 @@ func resourceConsulNodeCreate(d *schema.ResourceData, meta interface{}) error {
 		Node:       name,
 	}
 
-	if v, ok := d.GetOk("node_meta"); ok {
+	if v, ok := d.GetOk("meta"); ok {
 		nodeMeta := make(map[string]string)
 		for k, j := range v.(map[string]interface{}) {
 			nodeMeta[k] = j.(string)

--- a/consul/resource_consul_node.go
+++ b/consul/resource_consul_node.go
@@ -37,7 +37,7 @@ func resourceConsulNode() *schema.Resource {
 			"node_meta": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
-				ForceNew: true,
+				ForceNew: false,
 			},
 
 			"token": &schema.Schema{

--- a/consul/resource_consul_node_test.go
+++ b/consul/resource_consul_node_test.go
@@ -39,10 +39,10 @@ func TestAccConsulNode_nodeMeta(t *testing.T) {
 					testAccCheckConsulNodeExists(),
 					testAccCheckConsulNodeValue("consul_node.foo", "address", "127.0.0.1"),
 					testAccCheckConsulNodeValue("consul_node.foo", "name", "foo"),
-					testAccCheckConsulNodeValue("consul_node.foo", "node_meta.%", "3"),
-					testAccCheckConsulNodeValue("consul_node.foo", "node_meta.foo", "bar"),
-					testAccCheckConsulNodeValue("consul_node.foo", "node_meta.update", "this"),
-					testAccCheckConsulNodeValue("consul_node.foo", "node_meta.remove", "this"),
+					testAccCheckConsulNodeValue("consul_node.foo", "meta.%", "3"),
+					testAccCheckConsulNodeValue("consul_node.foo", "meta.foo", "bar"),
+					testAccCheckConsulNodeValue("consul_node.foo", "meta.update", "this"),
+					testAccCheckConsulNodeValue("consul_node.foo", "meta.remove", "this"),
 				),
 			},
 			resource.TestStep{
@@ -51,10 +51,10 @@ func TestAccConsulNode_nodeMeta(t *testing.T) {
 					testAccCheckConsulNodeExists(),
 					testAccCheckConsulNodeValue("consul_node.foo", "address", "127.0.0.1"),
 					testAccCheckConsulNodeValue("consul_node.foo", "name", "foo"),
-					testAccCheckConsulNodeValue("consul_node.foo", "node_meta.%", "2"),
-					testAccCheckConsulNodeValue("consul_node.foo", "node_meta.foo", "bar"),
-					testAccCheckConsulNodeValue("consul_node.foo", "node_meta.update", "yes"),
-					testAccCheckConsulNodeValueRemoved("consul_node.foo", "node_meta.remove"),
+					testAccCheckConsulNodeValue("consul_node.foo", "meta.%", "2"),
+					testAccCheckConsulNodeValue("consul_node.foo", "meta.foo", "bar"),
+					testAccCheckConsulNodeValue("consul_node.foo", "meta.update", "yes"),
+					testAccCheckConsulNodeValueRemoved("consul_node.foo", "meta.remove"),
 				),
 			},
 		},
@@ -139,7 +139,7 @@ resource "consul_node" "foo" {
 	name 	= "foo"
 	address = "127.0.0.1"
 
-	node_meta = {
+	meta = {
 		foo    = "bar"
 		update = "this"
 		remove = "this"
@@ -152,7 +152,7 @@ resource "consul_node" "foo" {
 	name 	= "foo"
 	address = "127.0.0.1"
 
-	node_meta = {
+	meta = {
 		foo     = "bar"
 		update  = "yes"
 	}

--- a/consul/resource_consul_node_test.go
+++ b/consul/resource_consul_node_test.go
@@ -19,8 +19,11 @@ func TestAccConsulNode_basic(t *testing.T) {
 				Config: testAccConsulNodeConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConsulNodeExists(),
-					testAccCheckConsulNodeValue("consul_catalog_entry.foo", "address", "127.0.0.1"),
-					testAccCheckConsulNodeValue("consul_catalog_entry.foo", "node", "foo"),
+					testAccCheckConsulNodeValue("consul_node.foo", "address", "127.0.0.1"),
+					testAccCheckConsulNodeValue("consul_node.foo", "name", "foo"),
+					testAccCheckConsulNodeValue("consul_node.foo", "node_meta.%", "2"),
+					testAccCheckConsulNodeValue("consul_node.foo", "node_meta.foo", "bar"),
+					testAccCheckConsulNodeValue("consul_node.foo", "node_meta.baz", "bam"),
 				),
 			},
 		},
@@ -80,8 +83,13 @@ func testAccCheckConsulNodeValue(n, attr, val string) resource.TestCheckFunc {
 }
 
 const testAccConsulNodeConfig = `
-resource "consul_catalog_entry" "foo" {
+resource "consul_node" "foo" {
+	name 	= "foo"
 	address = "127.0.0.1"
-	node = "foo"
+
+	node_meta = {
+		foo = "bar"
+		baz = "bam"
+	}
 }
 `

--- a/consul/resource_consul_node_test.go
+++ b/consul/resource_consul_node_test.go
@@ -16,7 +16,25 @@ func TestAccConsulNode_basic(t *testing.T) {
 		CheckDestroy: testAccCheckConsulNodeDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccConsulNodeConfig,
+				Config: testAccConsulNodeConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConsulNodeExists(),
+					testAccCheckConsulNodeValue("consul_node.foo", "address", "127.0.0.1"),
+					testAccCheckConsulNodeValue("consul_node.foo", "name", "foo"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConsulNode_nodeMeta(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() {},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConsulNodeDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccConsulNodeConfigNodeMeta,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConsulNodeExists(),
 					testAccCheckConsulNodeValue("consul_node.foo", "address", "127.0.0.1"),
@@ -82,7 +100,14 @@ func testAccCheckConsulNodeValue(n, attr, val string) resource.TestCheckFunc {
 	}
 }
 
-const testAccConsulNodeConfig = `
+const testAccConsulNodeConfigBasic = `
+resource "consul_node" "foo" {
+	name 	= "foo"
+	address = "127.0.0.1"
+}
+`
+
+const testAccConsulNodeConfigNodeMeta = `
 resource "consul_node" "foo" {
 	name 	= "foo"
 	address = "127.0.0.1"

--- a/website/docs/r/node.html.markdown
+++ b/website/docs/r/node.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the node being added to, or
   referenced in the catalog.
 
-* `nodemeta` - (Optional) KV metadata pairs
+* `node_meta` - (Optional) KV metadata pairs
 
 ## Attributes Reference
 
@@ -38,4 +38,4 @@ The following attributes are exported:
 
 * `address` - The address of the service.
 * `name` - The name of the service.
-* `nodemeta` - (https://www.consul.io/docs/agent/http/catalog.html#Meta) KV metadata pairs
+* `node_meta` - (https://www.consul.io/docs/agent/http/catalog.html#Meta) KV metadata pairs

--- a/website/docs/r/node.html.markdown
+++ b/website/docs/r/node.html.markdown
@@ -30,9 +30,12 @@ The following arguments are supported:
 * `name` - (Required) The name of the node being added to, or
   referenced in the catalog.
 
+* `nodemeta` - (Optional) KV metadata pairs
+
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `address` - The address of the service.
 * `name` - The name of the service.
+* `nodemeta` - (https://www.consul.io/docs/agent/http/catalog.html#Meta) KV metadata pairs

--- a/website/docs/r/node.html.markdown
+++ b/website/docs/r/node.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the node being added to, or
   referenced in the catalog.
 
-* `node_meta` - (Optional, map) Key/value pairs that are associated with the node.
+* `meta` - (Optional, map) Key/value pairs that are associated with the node.
 
 ## Attributes Reference
 
@@ -38,4 +38,4 @@ The following attributes are exported:
 
 * `address` - The address of the service.
 * `name` - The name of the service.
-* `node_meta` - (Optional, map) Key/value pairs that are associated with the node.
+* `meta` - (Optional, map) Key/value pairs that are associated with the node.

--- a/website/docs/r/node.html.markdown
+++ b/website/docs/r/node.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the node being added to, or
   referenced in the catalog.
 
-* `node_meta` - (Optional) KV metadata pairs
+* `node_meta` - (Optional, map) Key/value pairs that are associated with the node.
 
 ## Attributes Reference
 
@@ -38,4 +38,4 @@ The following attributes are exported:
 
 * `address` - The address of the service.
 * `name` - The name of the service.
-* `node_meta` - (https://www.consul.io/docs/agent/http/catalog.html#Meta) KV metadata pairs
+* `node_meta` - (Optional, map) Key/value pairs that are associated with the node.


### PR DESCRIPTION
Minor additions to the PR from @lawliet89 and @Zeldhyr renaming "node_meta" to "meta" in the TF resource. This aligns well with Terraform, and it shows up in both ways on the Consul API.

Closes #55 #38 #40