### PR TITLE
Fix #66 with document update

### DIFF
--- a/website/docs/d/key_prefix.html.markdown
+++ b/website/docs/d/key_prefix.html.markdown
@@ -49,7 +49,7 @@ data "consul_key_prefix" "web" {
 
 # Start our instance with the dynamic ami value
 resource "aws_instance" "web" {
-  ami = "${data.consul_key_prefix.web["app/launch_ami"]}"
+  ami = "${data.consul_key_prefix.web.subkeys["app/launch_ami"]}"
 
   # ...
 }


### PR DESCRIPTION
This fixes the documentation mistake to properly demonstrate the use of the subkeys hash.