### PR TITLE
Create node and service if deleted outside of terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 2.3.0 (Unreleased)
+
+BUG FIXES:
+
+* `consul_intention`, `consul_node` and `consul_service` now correctly re-creates
+resources deleted out-of-band ([#81](https://github.com/terraform-providers/terraform-provider-consul/issues/81) and [!69](https://github.com/terraform-providers/terraform-provider-consul/pull/69)).
+
 ## 2.2.0 (October 03, 2018)
 
 IMPROVEMENTS:

--- a/consul/resource_consul_intention.go
+++ b/consul/resource_consul_intention.go
@@ -172,6 +172,11 @@ func resourceConsulIntentionRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Failed to retrieve intention (dc: '%s'): %v", dc, err)
 	}
 
+	if intention == nil {
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("source_name", intention.SourceName)
 	d.Set("destination_name", intention.DestinationName)
 	d.Set("description", intention.Description)

--- a/consul/resource_consul_intention_test.go
+++ b/consul/resource_consul_intention_test.go
@@ -27,6 +27,18 @@ func TestAccConsulIntention_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("consul_intention.example", "meta.baz", "bat"),
 				),
 			},
+			resource.TestStep{
+				PreConfig: testAccRemoveConsulIntention(t),
+				Config:    testAccConsulIntentionConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_intention.example", "source_name", "api"),
+					resource.TestCheckResourceAttr("consul_intention.example", "destination_name", "db"),
+					resource.TestCheckResourceAttr("consul_intention.example", "action", "allow"),
+					resource.TestCheckResourceAttr("consul_intention.example", "description", "something about example"),
+					resource.TestCheckResourceAttr("consul_intention.example", "meta.foo", "bar"),
+					resource.TestCheckResourceAttr("consul_intention.example", "meta.baz", "bat"),
+				),
+			},
 		},
 	})
 }
@@ -61,6 +73,44 @@ func testAccCheckConsulIntentionDestroy(s *terraform.State) error {
 	return nil
 }
 
+func testAccRemoveConsulIntention(t *testing.T) func() {
+	return func() {
+		connect := testAccProvider.Meta().(*consulapi.Client).Connect()
+		qOpts := &consulapi.QueryOptions{}
+		iM := &consulapi.IntentionMatch{
+			By:    consulapi.IntentionMatchSource,
+			Names: []string{"api"},
+		}
+
+		resp, _, err := connect.IntentionMatch(iM, qOpts)
+		if err != nil {
+			t.Errorf("Failed to retrieve intentions by match err: %v", err)
+		}
+
+		intentions, hasMatch := resp["api"]
+		if !hasMatch {
+			t.Errorf("No intention with source api was found")
+		}
+
+		var iid string
+		for _, i := range intentions {
+			if _, ok := i.Meta["is_tf_acc_test"]; ok {
+				iid = i.ID
+				break
+			}
+		}
+
+		if iid == "" {
+			t.Errorf("Failed to find the intention created by Terraform")
+		}
+
+		_, err = connect.IntentionDelete(iid, &consulapi.WriteOptions{})
+		if err != nil {
+			t.Errorf("Failed to delete the intention. err: %s", err)
+		}
+	}
+}
+
 const testAccConsulIntentionConfigBasic = `
 resource "consul_intention" "example" {
 	source_name      = "api"
@@ -69,8 +119,9 @@ resource "consul_intention" "example" {
 
 	description = "something about example"
 	meta {
-		foo = "bar"
-		baz = "bat"
+		foo            = "bar"
+		baz            = "bat"
+		is_tf_acc_test = "yes"
 	}
 }
 `

--- a/consul/resource_consul_node.go
+++ b/consul/resource_consul_node.go
@@ -121,8 +121,13 @@ func resourceConsulNodeRead(d *schema.ResourceData, meta interface{}) error {
 	// Setup the operations using the datacenter
 	qOpts := consulapi.QueryOptions{Datacenter: dc}
 
-	if _, _, err := catalog.Node(name, &qOpts); err != nil {
+	n, _, err := catalog.Node(name, &qOpts)
+	if err != nil {
 		return fmt.Errorf("Failed to get name '%s' from Consul catalog: %v", name, err)
+	}
+
+	if n == nil {
+		d.SetId("")
 	}
 
 	return nil

--- a/consul/resource_consul_node_test.go
+++ b/consul/resource_consul_node_test.go
@@ -23,6 +23,25 @@ func TestAccConsulNode_basic(t *testing.T) {
 					testAccCheckConsulNodeValue("consul_node.foo", "name", "foo"),
 				),
 			},
+			resource.TestStep{
+				PreConfig: func() {
+					catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
+					wOpts := &consulapi.WriteOptions{}
+					dereg := &consulapi.CatalogDeregistration{
+						Node: "foo",
+					}
+					_, err := catalog.Deregister(dereg, wOpts)
+					if err != nil {
+						t.Errorf("err: %v", err)
+					}
+				},
+				Config: testAccConsulNodeConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConsulNodeExists(),
+					testAccCheckConsulNodeValue("consul_node.foo", "address", "127.0.0.1"),
+					testAccCheckConsulNodeValue("consul_node.foo", "name", "foo"),
+				),
+			},
 		},
 	})
 }

--- a/consul/resource_consul_node_test.go
+++ b/consul/resource_consul_node_test.go
@@ -24,18 +24,8 @@ func TestAccConsulNode_basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				PreConfig: func() {
-					catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
-					wOpts := &consulapi.WriteOptions{}
-					dereg := &consulapi.CatalogDeregistration{
-						Node: "foo",
-					}
-					_, err := catalog.Deregister(dereg, wOpts)
-					if err != nil {
-						t.Errorf("err: %v", err)
-					}
-				},
-				Config: testAccConsulNodeConfigBasic,
+				PreConfig: testAccRemoveConsulNode(t),
+				Config:    testAccConsulNodeConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConsulNodeExists(),
 					testAccCheckConsulNodeValue("consul_node.foo", "address", "127.0.0.1"),
@@ -143,6 +133,20 @@ func testAccCheckConsulNodeValueRemoved(n, attr string) resource.TestCheckFunc {
 			return fmt.Errorf("Attribute '%s' still present: %#v", attr, rn.Primary.Attributes)
 		}
 		return nil
+	}
+}
+
+func testAccRemoveConsulNode(t *testing.T) func() {
+	return func() {
+		catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
+		wOpts := &consulapi.WriteOptions{}
+		dereg := &consulapi.CatalogDeregistration{
+			Node: "foo",
+		}
+		_, err := catalog.Deregister(dereg, wOpts)
+		if err != nil {
+			t.Errorf("err: %v", err)
+		}
 	}
 }
 

--- a/consul/resource_consul_service_test.go
+++ b/consul/resource_consul_service_test.go
@@ -29,6 +29,31 @@ func TestAccConsulService_basic(t *testing.T) {
 					testAccConsulExternalSource,
 				),
 			},
+			resource.TestStep{
+				PreConfig: func() {
+					catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
+					wOpts := &consulapi.WriteOptions{}
+					dereg := &consulapi.CatalogDeregistration{
+						Node:      "comput-example",
+						ServiceID: "example",
+					}
+					_, err := catalog.Deregister(dereg, wOpts)
+					if err != nil {
+						t.Errorf("err: %v", err)
+					}
+				},
+				Config: testAccConsulServiceConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_service.example", "id", "example"),
+					resource.TestCheckResourceAttr("consul_service.example", "service_id", "example"),
+					resource.TestCheckResourceAttr("consul_service.example", "address", "www.hashicorptest.com"),
+					resource.TestCheckResourceAttr("consul_service.example", "node", "compute-example"),
+					resource.TestCheckResourceAttr("consul_service.example", "port", "80"),
+					resource.TestCheckResourceAttr("consul_service.example", "tags.#", "1"),
+					resource.TestCheckResourceAttr("consul_service.example", "tags.0", "tag0"),
+					testAccConsulExternalSource,
+				),
+			},
 		},
 	})
 }

--- a/consul/resource_consul_service_test.go
+++ b/consul/resource_consul_service_test.go
@@ -30,19 +30,8 @@ func TestAccConsulService_basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				PreConfig: func() {
-					catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
-					wOpts := &consulapi.WriteOptions{}
-					dereg := &consulapi.CatalogDeregistration{
-						Node:      "comput-example",
-						ServiceID: "example",
-					}
-					_, err := catalog.Deregister(dereg, wOpts)
-					if err != nil {
-						t.Errorf("err: %v", err)
-					}
-				},
-				Config: testAccConsulServiceConfigBasic,
+				PreConfig: testAccRemoveConsulService(t),
+				Config:    testAccConsulServiceConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("consul_service.example", "id", "example"),
 					resource.TestCheckResourceAttr("consul_service.example", "service_id", "example"),
@@ -158,6 +147,21 @@ func testAccCheckConsulServiceDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccRemoveConsulService(t *testing.T) func() {
+	return func() {
+		catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
+		wOpts := &consulapi.WriteOptions{}
+		dereg := &consulapi.CatalogDeregistration{
+			Node:      "comput-example",
+			ServiceID: "example",
+		}
+		_, err := catalog.Deregister(dereg, wOpts)
+		if err != nil {
+			t.Errorf("err: %v", err)
+		}
+	}
 }
 
 const testAccConsulServiceConfigNoNode = `


### PR DESCRIPTION
This changeset fixes an edge case of https://github.com/terraform-providers/terraform-provider-consul/pull/33 where if terraform state has consul catalog resource but consul catalog is actually empty the provider will raise an error rather than creating the node or service.

Acceptance Tests:

```
→ make testacc TEST=./consul TESTARGS="-run=TestAccConsulNode_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./consul -v -run=TestAccConsulNode_basic -timeout 120m
=== RUN   TestAccConsulNode_basic
--- PASS: TestAccConsulNode_basic (0.06s)
PASS
ok      github.com/terraform-providers/terraform-provider-consul/consul 0.107s

→ make testacc TEST=./consul TESTARGS="-run=TestAccConsulService_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./consul -v -run=TestAccConsulService_basic -timeout 120m
=== RUN   TestAccConsulService_basic
--- PASS: TestAccConsulService_basic (0.07s)
=== RUN   TestAccConsulService_basicModify
--- PASS: TestAccConsulService_basicModify (0.08s)
PASS
ok      github.com/terraform-providers/terraform-provider-consul/consul 0.167s

→ make testacc TEST=./consul TESTARGS="-run=TestAccConsulIntention_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./consul -v -run=TestAccConsulIntention_basic -timeout 120m
=== RUN   TestAccConsulIntention_basic
--- PASS: TestAccConsulIntention_basic (0.08s)
PASS
ok      github.com/terraform-providers/terraform-provider-consul/consul (cached)

```