### PR TITLE
Add import support to `consul_key_prefix`

### DIFF
--- a/consul/resource_consul_key_prefix.go
+++ b/consul/resource_consul_key_prefix.go
@@ -13,6 +13,9 @@ func resourceConsulKeyPrefix() *schema.Resource {
 		Update: resourceConsulKeyPrefixUpdate,
 		Read:   resourceConsulKeyPrefixRead,
 		Delete: resourceConsulKeyPrefixDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"datacenter": &schema.Schema{

--- a/website/docs/r/key_prefix.html.markdown
+++ b/website/docs/r/key_prefix.html.markdown
@@ -23,7 +23,8 @@ managing a set of related keys.
 To avoid accidentally clobbering matching data that existed in Consul before
 a `consul_key_prefix` resource was created, creation of a key prefix instance
 will fail if any matching keys are already present in the key/value store.
-If any conflicting data is present, you must first delete it manually.
+If any conflicting data is present, you must first delete it manually or
+explicitly import the prefix.
 
 ~> **Warning** After this resource is instantiated, Terraform takes control
 over *all* keys with the given path prefix, and will remove any matching keys
@@ -77,3 +78,12 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `datacenter` - The datacenter the keys are being read/written to.
+
+## Import
+
+`consul_key_prefix` can be imported. This is useful when the path already and
+you know all keys in path must be removed.
+
+```
+$ terraform import consul_key_prefix.myapp_config myapp/config/
+```


### PR DESCRIPTION
`consul_key_prefix` protect operators against unwanted key deletions by
requiring the choosen path to be empty.

While this is a nice default behavior, it can be intrusive to force it.
This change makes add import support to `consul_key_prefix` so the
operator can manually initialize Terraform state and override the default
behavior.

Close #77