### PR TITLE
Fix example HCL for consul_agent_config data resource

### DIFF
--- a/website/docs/d/agent_config.html.markdown
+++ b/website/docs/d/agent_config.html.markdown
@@ -20,7 +20,7 @@ from the agent specified in the `provider`.
 
 ```hcl
 data "consul_agent_config" "remote_agent" {}
-  
+
 output "consul_version" {
   value = "${data.consul_agent_config.remote_agent.version}"
 }

--- a/website/docs/d/agent_config.html.markdown
+++ b/website/docs/d/agent_config.html.markdown
@@ -20,9 +20,9 @@ from the agent specified in the `provider`.
 
 ```hcl
 data "consul_agent_config" "remote_agent" {}
-
-output "info" {
-  consul_version = "${data.consul_agent_config.version}"
+  
+output "consul_version" {
+  value = "${data.consul_agent_config.remote_agent.version}"
 }
 ```
 


### PR DESCRIPTION
The listed HCL example does not work in terraform 11.11. The output structure is incorrect (needs value instead of a variable name) as is the reference format (missing the name section). The new example works as tested on v0.11.11 against consul 1.4.