### PR TITLE
Add computed secret_id to the consul_acl_token attributes

### DIFF
--- a/consul/resource_consul_acl_token.go
+++ b/consul/resource_consul_acl_token.go
@@ -36,6 +36,11 @@ func resourceConsulACLToken() *schema.Resource {
 				Default:     false,
 				Description: "Flag to set the token local to the current datacenter.",
 			},
+			"secret_id": {
+				Type:        schema.TypeString,
+				Description: "The Secret ID of the token that will be created",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -103,6 +108,9 @@ func resourceConsulACLTokenRead(d *schema.ResourceData, meta interface{}) error 
 	}
 	if err = d.Set("local", aclToken.Local); err != nil {
 		return fmt.Errorf("Error while setting 'local': %s", err)
+	}
+	if err = d.Set("secret_id", aclToken.SecretID); err != nil {
+		return fmt.Errorf("Error while setting 'secret_id': %s", err)
 	}
 
 	return nil

--- a/website/docs/r/acl_token.html.markdown
+++ b/website/docs/r/acl_token.html.markdown
@@ -45,3 +45,4 @@ The following attributes are exported:
 * `description` - The description of the token.
 * `policies` - The list of policies attached to the token.
 * `local` - The flag to set the token local to the current datacenter.
+* `secret_id` - The Secret ID generated at token creation.


### PR DESCRIPTION
In order to store the token generated into vault for example.