### PR TITLE
Make consul acl {token,policy} importable

### DIFF
--- a/consul/resource_consul_acl_policy.go
+++ b/consul/resource_consul_acl_policy.go
@@ -14,6 +14,9 @@ func resourceConsulACLPolicy() *schema.Resource {
 		Read:   resourceConsulACLPolicyRead,
 		Update: resourceConsulACLPolicyUpdate,
 		Delete: resourceConsulACLPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/consul/resource_consul_acl_token.go
+++ b/consul/resource_consul_acl_token.go
@@ -14,6 +14,9 @@ func resourceConsulACLToken() *schema.Resource {
 		Read:   resourceConsulACLTokenRead,
 		Update: resourceConsulACLTokenUpdate,
 		Delete: resourceConsulACLTokenDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"description": {

--- a/consul/resource_consul_acl_token_test.go
+++ b/consul/resource_consul_acl_token_test.go
@@ -49,6 +49,43 @@ func TestAccConsulACLToken_basic(t *testing.T) {
 	})
 }
 
+func TestAccConsulACLToken_import(t *testing.T) {
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("bad state: %s", s)
+		}
+		v, ok := s[0].Attributes["description"]
+		if !ok || v != "test" {
+			return fmt.Errorf("bad description: %s", s)
+		}
+		v, ok = s[0].Attributes["policies.#"]
+		if !ok || v != "1" {
+			return fmt.Errorf("bad policies: %s", s)
+		}
+		v, ok = s[0].Attributes["local"]
+		if !ok || v != "true" {
+			return fmt.Errorf("bad local: %s", s)
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceACLTokenConfigBasic,
+			},
+			{
+				ResourceName:     "consul_acl_token.test",
+				ImportState:      true,
+				ImportStateCheck: checkFn,
+			},
+		},
+	})
+}
+
 const testResourceACLTokenConfigBasic = `
 resource "consul_acl_policy" "test" {
 	name = "test"

--- a/website/docs/r/acl_policy.html.markdown
+++ b/website/docs/r/acl_policy.html.markdown
@@ -42,3 +42,11 @@ The following attributes are exported:
 * `description` - The description of the policy.
 * `rules` - The rules of the policy.
 * `datacenters` - The datacenters of the policy.
+
+## Import
+
+`consul_acl_policy` can be imported:
+
+```
+$ terraform import consul_acl_policy.my-policy 1c90ef03-a6dd-6a8c-ac49-042ad3752896
+```

--- a/website/docs/r/acl_token.html.markdown
+++ b/website/docs/r/acl_token.html.markdown
@@ -45,3 +45,14 @@ The following attributes are exported:
 * `description` - The description of the token.
 * `policies` - The list of policies attached to the token.
 * `local` - The flag to set the token local to the current datacenter.
+
+
+## Import
+
+`consul_acl_token` can be imported. This is especially useful to manage the 
+anonymous and the master token with Terraform:
+
+```
+$ terraform import consul_acl_token.anonymous 00000000-0000-0000-0000-000000000002
+$ terraform import consul_acl_token.master-token 624d94ca-bc5c-f960-4e83-0a609cf588be
+```


### PR DESCRIPTION
Updating the policies associated with the anonymous token and the master token require them to be importable.

Fix https://github.com/terraform-providers/terraform-provider-consul/issues/100