### PR TITLE
Fix consul_node not detecting changes

### DIFF
--- a/consul/resource_consul_node.go
+++ b/consul/resource_consul_node.go
@@ -129,8 +129,15 @@ func resourceConsulNodeRead(d *schema.ResourceData, meta interface{}) error {
 
 	if n == nil {
 		d.SetId("")
+		return nil
 	}
 
+	if err = d.Set("address", n.Node.Address); err != nil {
+		return fmt.Errorf("Failed to set 'address': %v", err)
+	}
+	if err = d.Set("meta", n.Node.Meta); err != nil {
+		return fmt.Errorf("Failed to set 'meta': %v", err)
+	}
 	return nil
 }
 

--- a/consul/resource_consul_node_test.go
+++ b/consul/resource_consul_node_test.go
@@ -32,6 +32,18 @@ func TestAccConsulNode_basic(t *testing.T) {
 					testAccCheckConsulNodeValue("consul_node.foo", "name", "foo"),
 				),
 			},
+			{
+				// consul_node must detect changes made to its address...
+				PreConfig: testAccChangeConsulNodeAddress(t),
+				Config:    testAccConsulNodeConfigBasic,
+				Check:     testAccConsulNodeDetectAttributeChanges,
+			},
+			{
+				// ... and to its meta information
+				PreConfig: testAccChangeConsulNodeAddressMeta(t),
+				Config:    testAccConsulNodeConfigBasic,
+				Check:     testAccConsulNodeDetectAttributeChanges,
+			},
 		},
 	})
 }
@@ -150,10 +162,68 @@ func testAccRemoveConsulNode(t *testing.T) func() {
 	}
 }
 
+func testAccChangeConsulNodeAddress(t *testing.T) func() {
+	return func() {
+		catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
+		wOpts := &consulapi.WriteOptions{}
+
+		registration := &consulapi.CatalogRegistration{
+			Address:    "wrong_address",
+			Datacenter: "dc1",
+			Node:       "foo",
+			NodeMeta: map[string]string{
+				"foo": "bar",
+			},
+		}
+		_, err := catalog.Register(registration, wOpts)
+		if err != nil {
+			t.Errorf("err: %v", err)
+		}
+	}
+}
+func testAccChangeConsulNodeAddressMeta(t *testing.T) func() {
+	return func() {
+		catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
+		wOpts := &consulapi.WriteOptions{}
+
+		registration := &consulapi.CatalogRegistration{
+			Address:    "127.0.0.1",
+			Datacenter: "dc1",
+			Node:       "foo",
+		}
+		_, err := catalog.Register(registration, wOpts)
+		if err != nil {
+			t.Errorf("err: %v", err)
+		}
+	}
+}
+
+func testAccConsulNodeDetectAttributeChanges(*terraform.State) error {
+	catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
+	n, _, err := catalog.Node("foo", &consulapi.QueryOptions{})
+	if err != nil {
+		return fmt.Errorf("Failed to read 'foo': %v", err)
+	}
+	if n == nil {
+		return fmt.Errorf("No 'foo' node found")
+	}
+	if n.Node.Address != "127.0.0.1" {
+		return fmt.Errorf("Wrong address: %s", n.Node.Address)
+	}
+	if len(n.Node.Meta) != 1 || n.Node.Meta["foo"] != "bar" {
+		return fmt.Errorf("Wrong node meta: %v", n.Node.Meta)
+	}
+	return nil
+}
+
 const testAccConsulNodeConfigBasic = `
 resource "consul_node" "foo" {
 	name 	= "foo"
 	address = "127.0.0.1"
+
+	meta = {
+		foo     = "bar"
+	}
 }
 `
 

--- a/consul/resource_consul_service.go
+++ b/consul/resource_consul_service.go
@@ -75,9 +75,9 @@ func resourceConsulService() *schema.Resource {
 			},
 
 			"external": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Deprecated: "The external field has been deprecated and does nothing.",
 			},
 
 			"port": {
@@ -201,6 +201,9 @@ func resourceConsulServiceCreate(d *schema.ResourceData, meta interface{}) error
 		Service: &consulapi.AgentService{
 			Service: name,
 		},
+		// Creating a service should not modify the node
+		// See https://github.com/terraform-providers/terraform-provider-consul/issues/101
+		SkipNodeUpdate: true,
 	}
 
 	// By default, the ID will match the name of the service
@@ -235,14 +238,6 @@ func resourceConsulServiceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 		registration.Service.Tags = s
 	}
-
-	var nodeMeta map[string]string
-	nodeMeta = make(map[string]string)
-	if d.Get("external").(bool) {
-		nodeMeta["external-node"] = "true"
-		nodeMeta["external-probe"] = "true"
-	}
-	registration.NodeMeta = nodeMeta
 
 	checks, err := parseChecks(node, name, d)
 	if err != nil {
@@ -290,6 +285,8 @@ func resourceConsulServiceUpdate(d *schema.ResourceData, meta interface{}) error
 		Service: &consulapi.AgentService{
 			Service: name,
 		},
+		// Updating a service should not modify the node
+		SkipNodeUpdate: true,
 	}
 
 	// If we have a service_id
@@ -317,14 +314,6 @@ func resourceConsulServiceUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 		registration.Service.Tags = s
 	}
-
-	var nodeMeta map[string]string
-	nodeMeta = make(map[string]string)
-	if d.Get("external").(bool) {
-		nodeMeta["external-node"] = "true"
-		nodeMeta["external-probe"] = "true"
-	}
-	registration.NodeMeta = nodeMeta
 
 	checks, err := parseChecks(node, name, d)
 	if err != nil {
@@ -388,15 +377,6 @@ func resourceConsulServiceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if err = d.Set("node", service.Node); err != nil {
 		return fmt.Errorf("Failed to store 'node': %s", err)
-	}
-	if externalNode, present := service.NodeMeta["external-node"]; present && externalNode == "true" {
-		if err = d.Set("external", true); err != nil {
-			return fmt.Errorf("Failed to store 'external': %s", err)
-		}
-	} else {
-		if err = d.Set("external", false); err != nil {
-			return fmt.Errorf("Failed to store 'external': %s", err)
-		}
 	}
 
 	checks := make([]map[string]interface{}, 0)

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -92,9 +92,6 @@ of the `name` attribute.
 
 * `port` - (Optional, int) The port of the service.
 
-* `external` - (Optional, boolean) Whether to register this service as an
-  external service. This can be useful when using [Consul External Service Monitor](https://github.com/hashicorp/consul-esm)
-
 * `checks` - (Optional, list of checks) Health-checks to register to monitor the
   service. The list of attributes for each health-check is detailled below.
 
@@ -141,6 +138,5 @@ The following attributes are exported:
 * `name` - The name of the service.
 * `port` - The port of the service.
 * `tags` - The tags of the service.
-* `external` - Whether this is an external service.
 * `checks` - The list of health-checks associated with the service.
 * `datacenter` - The datacenter of the service.

--- a/website/docs/upgrading.html.markdown
+++ b/website/docs/upgrading.html.markdown
@@ -12,6 +12,47 @@ This page includes details on our compatibility promise and guidelines to
 follow when upgrading between versions of the provider. Whenever possible,
 we recommend verifying upgrades in isolated test environments.
 
+## Upgrading to 2.4.0
+
+### Changes to consul_service
+
+The `external` attribute introduced in 2.3.0 has been deprecated and does not
+update the associated Consul Node meta information anymore. The same functionnality
+can be done by setting the meta attribute on the `consul_node` resource:
+
+``` terraform
+# This was working in 2.3.0
+resource "consul_node" "compute" {
+	name    = "compute-example"
+	address = "www.hashicorptest.com"
+}
+
+resource "consul_service" "example1" {
+	name = "example"
+	node = "${consul_node.compute.name}"
+	port = 80
+
+	external = true
+}
+
+# This is working in 2.4.0
+resource "consul_node" "compute" {
+	name    = "compute-example"
+	address = "www.hashicorptest.com"
+
+  meta = {
+    "external-node" = "true"
+    "external-probe" = "true"
+  }
+}
+
+resource "consul_service" "example1" {
+	name = "example"
+	node = "${consul_node.compute.name}"
+	port = 80
+}
+```
+
 ## Upgrading to 2.0.0
 
 There were several major deprecation notices introduced in 2.0.0. This


### PR DESCRIPTION
`consul_node` were not updating their `address` and `meta` attributes during plans. This let another bug go unnoticed where `consul_service` could change `consul_node` attributes when `external` would be set to `true` (see https://github.com/terraform-providers/terraform-provider-consul/issues/101).

Multiple services could have conflicting configuration:

``` terraform
resource "consul_node" "compute" {
	name    = "compute-example"
	address = "www.hashicorptest.com"
}

resource "consul_service" "example1" {
	name = "example"
	node = "${consul_node.compute.name}"
	port = 80

	external = true
}


resource "consul_service" "example2" {
	name = "example"
	node = "${consul_node.compute.name}"
	port = 80

	external = true
}

// What should be the node's meta.external-probe and meta.external-node?
```

This patch fix `resourceConsulNodeRead()` and deprecate `external` from `consul_service`.
Another option would have been move `external` to the `consul_node` resource but it would then have conflicted with the `meta` attribute. We could use a custom `DiffSuppressFunc` to avoid this but I'm not sure it is worth the maintenance cost.