### PR TITLE
Use provider datacenter as default when the agent cannot be reached

### DIFF
--- a/consul/data_source_consul_agent_config.go
+++ b/consul/data_source_consul_agent_config.go
@@ -2,7 +2,7 @@ package consul
 
 import (
 	"fmt"
-	consulapi "github.com/hashicorp/consul/api"
+
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -51,7 +51,10 @@ func dataSourceConsulAgentConfig() *schema.Resource {
 }
 
 func dataSourceConsulAgentConfigRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	agentSelf, err := client.Agent().Self()
 	if err != nil {
 		return err

--- a/consul/data_source_consul_agent_config.go
+++ b/consul/data_source_consul_agent_config.go
@@ -51,11 +51,7 @@ func dataSourceConsulAgentConfig() *schema.Resource {
 }
 
 func dataSourceConsulAgentConfigRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
-	agentSelf, err := client.Agent().Self()
+	agentSelf, err := getClient(meta).Agent().Self()
 	if err != nil {
 		return err
 	}

--- a/consul/data_source_consul_agent_self.go
+++ b/consul/data_source_consul_agent_self.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"time"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -735,7 +734,10 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 }
 
 func dataSourceConsulAgentSelfRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	info, err := client.Agent().Self()
 	if err != nil {
 		return err

--- a/consul/data_source_consul_agent_self.go
+++ b/consul/data_source_consul_agent_self.go
@@ -734,11 +734,7 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 }
 
 func dataSourceConsulAgentSelfRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
-	info, err := client.Agent().Self()
+	info, err := getClient(meta).Agent().Self()
 	if err != nil {
 		return err
 	}

--- a/consul/data_source_consul_autopilot_health.go
+++ b/consul/data_source_consul_autopilot_health.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"fmt"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -88,10 +87,16 @@ func dataSourceConsulAutopilotHealth() *schema.Resource {
 }
 
 func dataSourceConsulAutopilotHealthRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	operator := client.Operator()
 
-	queryOpts, err := getQueryOpts(d, client)
+	queryOpts, err := getQueryOpts(d, client, meta)
+	if err != nil {
+		return err
+	}
 	if datacenter, ok := d.GetOk("datacenter"); ok {
 		queryOpts.Datacenter = datacenter.(string)
 	}

--- a/consul/data_source_consul_autopilot_health.go
+++ b/consul/data_source_consul_autopilot_health.go
@@ -87,10 +87,7 @@ func dataSourceConsulAutopilotHealth() *schema.Resource {
 }
 
 func dataSourceConsulAutopilotHealthRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	operator := client.Operator()
 
 	queryOpts, err := getQueryOpts(d, client, meta)

--- a/consul/data_source_consul_key_prefix.go
+++ b/consul/data_source_consul_key_prefix.go
@@ -67,10 +67,8 @@ func dataSourceConsulKeyPrefix() *schema.Resource {
 }
 
 func dataSourceConsulKeyPrefixRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
+
 	kv := client.KV()
 	token := d.Get("token").(string)
 	dc, err := getDC(d, client, meta)

--- a/consul/data_source_consul_key_prefix.go
+++ b/consul/data_source_consul_key_prefix.go
@@ -1,7 +1,6 @@
 package consul
 
 import (
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -68,10 +67,13 @@ func dataSourceConsulKeyPrefix() *schema.Resource {
 }
 
 func dataSourceConsulKeyPrefixRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	kv := client.KV()
 	token := d.Get("token").(string)
-	dc, err := getDC(d, client)
+	dc, err := getDC(d, client, meta)
 	if err != nil {
 		return err
 	}

--- a/consul/data_source_consul_keys.go
+++ b/consul/data_source_consul_keys.go
@@ -54,10 +54,7 @@ func dataSourceConsulKeys() *schema.Resource {
 }
 
 func dataSourceConsulKeysRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	kv := client.KV()
 	token := d.Get("token").(string)
 	dc, err := getDC(d, client, meta)

--- a/consul/data_source_consul_keys.go
+++ b/consul/data_source_consul_keys.go
@@ -1,7 +1,6 @@
 package consul
 
 import (
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -55,10 +54,13 @@ func dataSourceConsulKeys() *schema.Resource {
 }
 
 func dataSourceConsulKeysRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	kv := client.KV()
 	token := d.Get("token").(string)
-	dc, err := getDC(d, client)
+	dc, err := getDC(d, client, meta)
 	if err != nil {
 		return err
 	}

--- a/consul/data_source_consul_nodes.go
+++ b/consul/data_source_consul_nodes.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"fmt"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -95,10 +94,13 @@ func dataSourceConsulNodes() *schema.Resource {
 }
 
 func dataSourceConsulNodesRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	// Parse out data source filters to populate Consul's query options
-	queryOpts, err := getQueryOpts(d, client)
+	queryOpts, err := getQueryOpts(d, client, meta)
 	if err != nil {
 		return errwrap.Wrapf("unable to get query options for fetching catalog nodes: {{err}}", err)
 	}

--- a/consul/data_source_consul_nodes.go
+++ b/consul/data_source_consul_nodes.go
@@ -94,10 +94,7 @@ func dataSourceConsulNodes() *schema.Resource {
 }
 
 func dataSourceConsulNodesRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 
 	// Parse out data source filters to populate Consul's query options
 	queryOpts, err := getQueryOpts(d, client, meta)

--- a/consul/data_source_consul_service.go
+++ b/consul/data_source_consul_service.go
@@ -135,10 +135,7 @@ func dataSourceConsulService() *schema.Resource {
 }
 
 func dataSourceConsulServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 
 	// Parse out data source filters to populate Consul's query options
 	queryOpts, err := getQueryOpts(d, client, meta)

--- a/consul/data_source_consul_service.go
+++ b/consul/data_source_consul_service.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sort"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -136,10 +135,13 @@ func dataSourceConsulService() *schema.Resource {
 }
 
 func dataSourceConsulServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	// Parse out data source filters to populate Consul's query options
-	queryOpts, err := getQueryOpts(d, client)
+	queryOpts, err := getQueryOpts(d, client, meta)
 	if err != nil {
 		return errwrap.Wrapf("unable to get query options for fetching catalog services: {{err}}", err)
 	}

--- a/consul/data_source_consul_services.go
+++ b/consul/data_source_consul_services.go
@@ -58,10 +58,7 @@ func dataSourceConsulServices() *schema.Resource {
 }
 
 func dataSourceConsulServicesRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 
 	// Parse out data source filters to populate Consul's query options
 	queryOpts, err := getQueryOpts(d, client, meta)

--- a/consul/data_source_consul_services.go
+++ b/consul/data_source_consul_services.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -59,10 +58,13 @@ func dataSourceConsulServices() *schema.Resource {
 }
 
 func dataSourceConsulServicesRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	// Parse out data source filters to populate Consul's query options
-	queryOpts, err := getQueryOpts(d, client)
+	queryOpts, err := getQueryOpts(d, client, meta)
 	if err != nil {
 		return errwrap.Wrapf("unable to get query options for fetching catalog services: {{err}}", err)
 	}

--- a/consul/query_options.go
+++ b/consul/query_options.go
@@ -69,7 +69,7 @@ var schemaQueryOpts = &schema.Schema{
 	},
 }
 
-func getQueryOpts(d *schema.ResourceData, client *consulapi.Client) (*consulapi.QueryOptions, error) {
+func getQueryOpts(d *schema.ResourceData, client *consulapi.Client, meta interface{}) (*consulapi.QueryOptions, error) {
 	queryOpts := &consulapi.QueryOptions{}
 
 	if v, ok := d.GetOk(queryOptAllowStale); ok {
@@ -81,7 +81,7 @@ func getQueryOpts(d *schema.ResourceData, client *consulapi.Client) (*consulapi.
 	}
 
 	if queryOpts.Datacenter == "" {
-		dc, err := getDC(d, client)
+		dc, err := getDC(d, client, meta)
 		if err != nil {
 			return nil, err
 		}

--- a/consul/resource_consul_acl_policy.go
+++ b/consul/resource_consul_acl_policy.go
@@ -42,7 +42,10 @@ func resourceConsulACLPolicy() *schema.Resource {
 }
 
 func resourceConsulACLPolicyCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[DEBUG] Creating ACL policy")
 
@@ -74,7 +77,10 @@ func resourceConsulACLPolicyCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulACLPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	id := d.Id()
 	log.Printf("[DEBUG] Reading ACL policy %q", id)
@@ -111,7 +117,10 @@ func resourceConsulACLPolicyRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceConsulACLPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	id := d.Id()
 	log.Printf("[DEBUG] Updating ACL policy %q", id)
@@ -132,7 +141,7 @@ func resourceConsulACLPolicyUpdate(d *schema.ResourceData, meta interface{}) err
 		aclPolicy.Datacenters = s
 	}
 
-	_, _, err := client.ACL().PolicyUpdate(&aclPolicy, nil)
+	_, _, err = client.ACL().PolicyUpdate(&aclPolicy, nil)
 	if err != nil {
 		return fmt.Errorf("error updating ACL policy %q: %s", id, err)
 	}
@@ -142,12 +151,15 @@ func resourceConsulACLPolicyUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulACLPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	id := d.Id()
 
 	log.Printf("[DEBUG] Deleting ACL policy %q", id)
-	_, err := client.ACL().PolicyDelete(id, nil)
+	_, err = client.ACL().PolicyDelete(id, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting ACL policy %q: %s", id, err)
 	}

--- a/consul/resource_consul_acl_policy.go
+++ b/consul/resource_consul_acl_policy.go
@@ -42,10 +42,7 @@ func resourceConsulACLPolicy() *schema.Resource {
 }
 
 func resourceConsulACLPolicyCreate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 
 	log.Printf("[DEBUG] Creating ACL policy")
 
@@ -77,10 +74,7 @@ func resourceConsulACLPolicyCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulACLPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 
 	id := d.Id()
 	log.Printf("[DEBUG] Reading ACL policy %q", id)
@@ -117,10 +111,7 @@ func resourceConsulACLPolicyRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceConsulACLPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 
 	id := d.Id()
 	log.Printf("[DEBUG] Updating ACL policy %q", id)
@@ -141,7 +132,7 @@ func resourceConsulACLPolicyUpdate(d *schema.ResourceData, meta interface{}) err
 		aclPolicy.Datacenters = s
 	}
 
-	_, _, err = client.ACL().PolicyUpdate(&aclPolicy, nil)
+	_, _, err := client.ACL().PolicyUpdate(&aclPolicy, nil)
 	if err != nil {
 		return fmt.Errorf("error updating ACL policy %q: %s", id, err)
 	}
@@ -151,15 +142,12 @@ func resourceConsulACLPolicyUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulACLPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 
 	id := d.Id()
 
 	log.Printf("[DEBUG] Deleting ACL policy %q", id)
-	_, err = client.ACL().PolicyDelete(id, nil)
+	_, err := client.ACL().PolicyDelete(id, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting ACL policy %q: %s", id, err)
 	}

--- a/consul/resource_consul_acl_policy_test.go
+++ b/consul/resource_consul_acl_policy_test.go
@@ -9,10 +9,7 @@ import (
 )
 
 func testAccCheckConsulACLPolicyDestroy(s *terraform.State) error {
-	client, err := testAccProvider.Meta().(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(testAccProvider.Meta())
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "consul_acl" {

--- a/consul/resource_consul_acl_policy_test.go
+++ b/consul/resource_consul_acl_policy_test.go
@@ -4,13 +4,15 @@ import (
 	"fmt"
 	"testing"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func testAccCheckConsulACLPolicyDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*consulapi.Client)
+	client, err := testAccProvider.Meta().(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "consul_acl" {

--- a/consul/resource_consul_acl_token.go
+++ b/consul/resource_consul_acl_token.go
@@ -41,7 +41,10 @@ func resourceConsulACLToken() *schema.Resource {
 }
 
 func resourceConsulACLTokenCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[DEBUG] Creating ACL token")
 
@@ -75,7 +78,10 @@ func resourceConsulACLTokenCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceConsulACLTokenRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	id := d.Id()
 	log.Printf("[DEBUG] Reading ACL token %q", id)
@@ -139,12 +145,15 @@ func resourceConsulACLTokenUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceConsulACLTokenDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	id := d.Id()
 
 	log.Printf("[DEBUG] Deleting ACL token %q", id)
-	_, err := client.ACL().TokenDelete(id, nil)
+	_, err = client.ACL().TokenDelete(id, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting ACL token %q: %s", id, err)
 	}

--- a/consul/resource_consul_acl_token.go
+++ b/consul/resource_consul_acl_token.go
@@ -41,10 +41,7 @@ func resourceConsulACLToken() *schema.Resource {
 }
 
 func resourceConsulACLTokenCreate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 
 	log.Printf("[DEBUG] Creating ACL token")
 
@@ -78,10 +75,7 @@ func resourceConsulACLTokenCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceConsulACLTokenRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 
 	id := d.Id()
 	log.Printf("[DEBUG] Reading ACL token %q", id)
@@ -145,15 +139,12 @@ func resourceConsulACLTokenUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceConsulACLTokenDelete(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 
 	id := d.Id()
 
 	log.Printf("[DEBUG] Deleting ACL token %q", id)
-	_, err = client.ACL().TokenDelete(id, nil)
+	_, err := client.ACL().TokenDelete(id, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting ACL token %q: %s", id, err)
 	}

--- a/consul/resource_consul_acl_token_test.go
+++ b/consul/resource_consul_acl_token_test.go
@@ -31,7 +31,8 @@ func testAccCheckConsulACLTokenDestroy(s *terraform.State) error {
 
 func TestAccConsulACLToken_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		Providers:    testAccProviders,
+		Providers: testAccProviders,
+
 		PreCheck:     func() { testAccPreCheck(t) },
 		CheckDestroy: testAccCheckConsulACLTokenDestroy,
 		Steps: []resource.TestStep{

--- a/consul/resource_consul_acl_token_test.go
+++ b/consul/resource_consul_acl_token_test.go
@@ -9,10 +9,7 @@ import (
 )
 
 func testAccCheckConsulACLTokenDestroy(s *terraform.State) error {
-	client, err := testAccProvider.Meta().(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(testAccProvider.Meta())
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "consul_acl" {

--- a/consul/resource_consul_acl_token_test.go
+++ b/consul/resource_consul_acl_token_test.go
@@ -4,13 +4,15 @@ import (
 	"fmt"
 	"testing"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func testAccCheckConsulACLTokenDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*consulapi.Client)
+	client, err := testAccProvider.Meta().(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "consul_acl" {

--- a/consul/resource_consul_agent_service.go
+++ b/consul/resource_consul_agent_service.go
@@ -45,10 +45,7 @@ func resourceConsulAgentService() *schema.Resource {
 }
 
 func resourceConsulAgentServiceCreate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	agent := client.Agent()
 
 	name := d.Get("name").(string)
@@ -97,10 +94,7 @@ func resourceConsulAgentServiceCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceConsulAgentServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	agent := client.Agent()
 
 	name := d.Get("name").(string)
@@ -126,10 +120,7 @@ func resourceConsulAgentServiceRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceConsulAgentServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	catalog := client.Agent()
 
 	id := d.Id()

--- a/consul/resource_consul_agent_service.go
+++ b/consul/resource_consul_agent_service.go
@@ -45,7 +45,10 @@ func resourceConsulAgentService() *schema.Resource {
 }
 
 func resourceConsulAgentServiceCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	agent := client.Agent()
 
 	name := d.Get("name").(string)
@@ -94,7 +97,10 @@ func resourceConsulAgentServiceCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceConsulAgentServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	agent := client.Agent()
 
 	name := d.Get("name").(string)
@@ -120,7 +126,10 @@ func resourceConsulAgentServiceRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceConsulAgentServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	catalog := client.Agent()
 
 	id := d.Id()

--- a/consul/resource_consul_agent_service_test.go
+++ b/consul/resource_consul_agent_service_test.go
@@ -32,10 +32,7 @@ func TestAccConsulAgentService_basic(t *testing.T) {
 }
 
 func testAccCheckConsulAgentServiceDestroy(s *terraform.State) error {
-	client, err := testAccProvider.Meta().(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(testAccProvider.Meta())
 	agent := client.Agent()
 	services, err := agent.Services()
 	if err != nil {
@@ -50,10 +47,7 @@ func testAccCheckConsulAgentServiceDestroy(s *terraform.State) error {
 
 func testAccCheckConsulAgentServiceExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client, err := testAccProvider.Meta().(*Config).Client()
-		if err != nil {
-			return err
-		}
+		client := getClient(testAccProvider.Meta())
 		agent := client.Agent()
 		services, err := agent.Services()
 		if err != nil {

--- a/consul/resource_consul_agent_service_test.go
+++ b/consul/resource_consul_agent_service_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -33,7 +32,11 @@ func TestAccConsulAgentService_basic(t *testing.T) {
 }
 
 func testAccCheckConsulAgentServiceDestroy(s *terraform.State) error {
-	agent := testAccProvider.Meta().(*consulapi.Client).Agent()
+	client, err := testAccProvider.Meta().(*Config).Client()
+	if err != nil {
+		return err
+	}
+	agent := client.Agent()
 	services, err := agent.Services()
 	if err != nil {
 		return fmt.Errorf("Could not retrieve services: %#v", err)
@@ -47,7 +50,11 @@ func testAccCheckConsulAgentServiceDestroy(s *terraform.State) error {
 
 func testAccCheckConsulAgentServiceExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		agent := testAccProvider.Meta().(*consulapi.Client).Agent()
+		client, err := testAccProvider.Meta().(*Config).Client()
+		if err != nil {
+			return err
+		}
+		agent := client.Agent()
 		services, err := agent.Services()
 		if err != nil {
 			return err

--- a/consul/resource_consul_autopilot_config.go
+++ b/consul/resource_consul_autopilot_config.go
@@ -66,10 +66,7 @@ func resourceConsulAutopilotConfigCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceConsulAutopilotConfigUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	operator := client.Operator()
 
 	dc, err := getDC(d, client, meta)
@@ -107,10 +104,7 @@ func resourceConsulAutopilotConfigUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceConsulAutopilotConfigRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	operator := client.Operator()
 
 	dc, err := getDC(d, client, meta)

--- a/consul/resource_consul_autopilot_config.go
+++ b/consul/resource_consul_autopilot_config.go
@@ -66,10 +66,13 @@ func resourceConsulAutopilotConfigCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceConsulAutopilotConfigUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	operator := client.Operator()
 
-	dc, err := getDC(d, client)
+	dc, err := getDC(d, client, meta)
 	if err != nil {
 		return err
 	}
@@ -104,10 +107,13 @@ func resourceConsulAutopilotConfigUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceConsulAutopilotConfigRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	operator := client.Operator()
 
-	dc, err := getDC(d, client)
+	dc, err := getDC(d, client, meta)
 	if err != nil {
 		return err
 	}

--- a/consul/resource_consul_autopilot_config_test.go
+++ b/consul/resource_consul_autopilot_config_test.go
@@ -63,10 +63,7 @@ func TestAccConsulAutopilotConfig_parseduration(t *testing.T) {
 // when destroying the consul_autopilot_config resource, the configuration
 // should not be changed
 func testFinalConfiguration(s *terraform.State) error {
-	client, err := testAccProvider.Meta().(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(testAccProvider.Meta())
 	operator := client.Operator()
 	qOpts := &consulapi.QueryOptions{}
 	config, err := operator.AutopilotGetConfiguration(qOpts)

--- a/consul/resource_consul_autopilot_config_test.go
+++ b/consul/resource_consul_autopilot_config_test.go
@@ -63,7 +63,11 @@ func TestAccConsulAutopilotConfig_parseduration(t *testing.T) {
 // when destroying the consul_autopilot_config resource, the configuration
 // should not be changed
 func testFinalConfiguration(s *terraform.State) error {
-	operator := testAccProvider.Meta().(*consulapi.Client).Operator()
+	client, err := testAccProvider.Meta().(*Config).Client()
+	if err != nil {
+		return err
+	}
+	operator := client.Operator()
 	qOpts := &consulapi.QueryOptions{}
 	config, err := operator.AutopilotGetConfiguration(qOpts)
 	if err != nil {

--- a/consul/resource_consul_catalog_entry.go
+++ b/consul/resource_consul_catalog_entry.go
@@ -118,10 +118,7 @@ func resourceConsulCatalogEntryServicesHash(v interface{}) int {
 }
 
 func resourceConsulCatalogEntryCreate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	catalog := client.Catalog()
 
 	var dc string
@@ -215,10 +212,7 @@ func resourceConsulCatalogEntryCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceConsulCatalogEntryRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	catalog := client.Catalog()
 
 	// Get the DC, error if not available.
@@ -244,10 +238,7 @@ func resourceConsulCatalogEntryRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceConsulCatalogEntryDelete(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	catalog := client.Catalog()
 
 	var dc string

--- a/consul/resource_consul_catalog_entry.go
+++ b/consul/resource_consul_catalog_entry.go
@@ -118,7 +118,10 @@ func resourceConsulCatalogEntryServicesHash(v interface{}) int {
 }
 
 func resourceConsulCatalogEntryCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	catalog := client.Catalog()
 
 	var dc string
@@ -126,7 +129,7 @@ func resourceConsulCatalogEntryCreate(d *schema.ResourceData, meta interface{}) 
 		dc = v.(string)
 	} else {
 		var err error
-		if dc, err = getDC(d, client); err != nil {
+		if dc, err = getDC(d, client, meta); err != nil {
 			return err
 		}
 	}
@@ -212,7 +215,10 @@ func resourceConsulCatalogEntryCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceConsulCatalogEntryRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	catalog := client.Catalog()
 
 	// Get the DC, error if not available.
@@ -238,7 +244,10 @@ func resourceConsulCatalogEntryRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceConsulCatalogEntryDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	catalog := client.Catalog()
 
 	var dc string
@@ -246,7 +255,7 @@ func resourceConsulCatalogEntryDelete(d *schema.ResourceData, meta interface{}) 
 		dc = v.(string)
 	} else {
 		var err error
-		if dc, err = getDC(d, client); err != nil {
+		if dc, err = getDC(d, client, meta); err != nil {
 			return err
 		}
 	}

--- a/consul/resource_consul_catalog_entry_test.go
+++ b/consul/resource_consul_catalog_entry_test.go
@@ -64,7 +64,11 @@ func TestAccConsulCatalogEntry_extremove(t *testing.T) {
 }
 
 func testAccCheckConsulCatalogEntryDestroy(s *terraform.State) error {
-	catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
+	client, err := testAccProvider.Meta().(*Config).Client()
+	if err != nil {
+		return err
+	}
+	catalog := client.Catalog()
 	qOpts := consulapi.QueryOptions{}
 	services, _, err := catalog.Services(&qOpts)
 	if err != nil {
@@ -79,13 +83,17 @@ func testAccCheckConsulCatalogEntryDestroy(s *terraform.State) error {
 
 func testAccCheckConsulCatalogEntryDeregister(node string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
+		client, err := testAccProvider.Meta().(*Config).Client()
+		if err != nil {
+			return err
+		}
+		catalog := client.Catalog()
 		wOpts := consulapi.WriteOptions{}
 
 		deregistration := consulapi.CatalogDeregistration{
 			Node: node,
 		}
-		_, err := catalog.Deregister(&deregistration, &wOpts)
+		_, err = catalog.Deregister(&deregistration, &wOpts)
 		if err != nil {
 			return err
 		}
@@ -105,7 +113,11 @@ func testAccCheckConsulCatalogEntryDeregister(node string) resource.TestCheckFun
 
 func testAccCheckConsulCatalogEntryExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
+		client, err := testAccProvider.Meta().(*Config).Client()
+		if err != nil {
+			return err
+		}
+		catalog := client.Catalog()
 		qOpts := consulapi.QueryOptions{}
 		services, _, err := catalog.Services(&qOpts)
 		if err != nil {

--- a/consul/resource_consul_catalog_entry_test.go
+++ b/consul/resource_consul_catalog_entry_test.go
@@ -64,10 +64,7 @@ func TestAccConsulCatalogEntry_extremove(t *testing.T) {
 }
 
 func testAccCheckConsulCatalogEntryDestroy(s *terraform.State) error {
-	client, err := testAccProvider.Meta().(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(testAccProvider.Meta())
 	catalog := client.Catalog()
 	qOpts := consulapi.QueryOptions{}
 	services, _, err := catalog.Services(&qOpts)
@@ -83,17 +80,14 @@ func testAccCheckConsulCatalogEntryDestroy(s *terraform.State) error {
 
 func testAccCheckConsulCatalogEntryDeregister(node string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client, err := testAccProvider.Meta().(*Config).Client()
-		if err != nil {
-			return err
-		}
+		client := getClient(testAccProvider.Meta())
 		catalog := client.Catalog()
 		wOpts := consulapi.WriteOptions{}
 
 		deregistration := consulapi.CatalogDeregistration{
 			Node: node,
 		}
-		_, err = catalog.Deregister(&deregistration, &wOpts)
+		_, err := catalog.Deregister(&deregistration, &wOpts)
 		if err != nil {
 			return err
 		}
@@ -113,10 +107,7 @@ func testAccCheckConsulCatalogEntryDeregister(node string) resource.TestCheckFun
 
 func testAccCheckConsulCatalogEntryExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client, err := testAccProvider.Meta().(*Config).Client()
-		if err != nil {
-			return err
-		}
+		client := getClient(testAccProvider.Meta())
 		catalog := client.Catalog()
 		qOpts := consulapi.QueryOptions{}
 		services, _, err := catalog.Services(&qOpts)

--- a/consul/resource_consul_intention.go
+++ b/consul/resource_consul_intention.go
@@ -50,7 +50,10 @@ func resourceConsulIntention() *schema.Resource {
 }
 
 func resourceConsulIntentionCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	connect := client.Connect()
 
 	sourceName := d.Get("source_name").(string)
@@ -104,7 +107,10 @@ func resourceConsulIntentionCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulIntentionUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	connect := client.Connect()
 
 	sourceName := d.Get("source_name").(string)
@@ -156,7 +162,10 @@ func resourceConsulIntentionUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulIntentionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	connect := client.Connect()
 
 	dc := ""
@@ -187,7 +196,10 @@ func resourceConsulIntentionRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceConsulIntentionDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	connect := client.Connect()
 	id := d.Id()
 

--- a/consul/resource_consul_intention.go
+++ b/consul/resource_consul_intention.go
@@ -50,10 +50,7 @@ func resourceConsulIntention() *schema.Resource {
 }
 
 func resourceConsulIntentionCreate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	connect := client.Connect()
 
 	sourceName := d.Get("source_name").(string)
@@ -107,10 +104,7 @@ func resourceConsulIntentionCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulIntentionUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	connect := client.Connect()
 
 	sourceName := d.Get("source_name").(string)
@@ -162,10 +156,7 @@ func resourceConsulIntentionUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulIntentionRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	connect := client.Connect()
 
 	dc := ""
@@ -196,10 +187,7 @@ func resourceConsulIntentionRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceConsulIntentionDelete(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	connect := client.Connect()
 	id := d.Id()
 

--- a/consul/resource_consul_intention_test.go
+++ b/consul/resource_consul_intention_test.go
@@ -58,10 +58,7 @@ func TestAccConsulIntention_badAction(t *testing.T) {
 }
 
 func testAccCheckConsulIntentionDestroy(s *terraform.State) error {
-	client, err := testAccProvider.Meta().(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(testAccProvider.Meta())
 
 	qOpts := consulapi.QueryOptions{}
 	intentions, _, err := client.Connect().Intentions(&qOpts)
@@ -78,10 +75,7 @@ func testAccCheckConsulIntentionDestroy(s *terraform.State) error {
 
 func testAccRemoveConsulIntention(t *testing.T) func() {
 	return func() {
-		client, err := testAccProvider.Meta().(*Config).Client()
-		if err != nil {
-			t.Fatal(err)
-		}
+		client := getClient(testAccProvider.Meta())
 		connect := client.Connect()
 		qOpts := &consulapi.QueryOptions{}
 		iM := &consulapi.IntentionMatch{

--- a/consul/resource_consul_key_prefix.go
+++ b/consul/resource_consul_key_prefix.go
@@ -72,10 +72,7 @@ func resourceConsulKeyPrefix() *schema.Resource {
 }
 
 func resourceConsulKeyPrefixCreate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	kv := client.KV()
 	token := d.Get("token").(string)
 	dc, err := getDC(d, client, meta)
@@ -154,10 +151,7 @@ func resourceConsulKeyPrefixCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulKeyPrefixUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	kv := client.KV()
 	token := d.Get("token").(string)
 	dc, err := getDC(d, client, meta)
@@ -268,10 +262,7 @@ func resourceConsulKeyPrefixUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulKeyPrefixRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	kv := client.KV()
 	token := d.Get("token").(string)
 	dc, err := getDC(d, client, meta)
@@ -341,10 +332,7 @@ func resourceConsulKeyPrefixRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceConsulKeyPrefixDelete(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	kv := client.KV()
 	token := d.Get("token").(string)
 	dc, err := getDC(d, client, meta)

--- a/consul/resource_consul_key_prefix.go
+++ b/consul/resource_consul_key_prefix.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"fmt"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -73,10 +72,13 @@ func resourceConsulKeyPrefix() *schema.Resource {
 }
 
 func resourceConsulKeyPrefixCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	kv := client.KV()
 	token := d.Get("token").(string)
-	dc, err := getDC(d, client)
+	dc, err := getDC(d, client, meta)
 	if err != nil {
 		return err
 	}
@@ -152,10 +154,13 @@ func resourceConsulKeyPrefixCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulKeyPrefixUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	kv := client.KV()
 	token := d.Get("token").(string)
-	dc, err := getDC(d, client)
+	dc, err := getDC(d, client, meta)
 	if err != nil {
 		return err
 	}
@@ -263,10 +268,13 @@ func resourceConsulKeyPrefixUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulKeyPrefixRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	kv := client.KV()
 	token := d.Get("token").(string)
-	dc, err := getDC(d, client)
+	dc, err := getDC(d, client, meta)
 	if err != nil {
 		return err
 	}
@@ -333,10 +341,13 @@ func resourceConsulKeyPrefixRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceConsulKeyPrefixDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	kv := client.KV()
 	token := d.Get("token").(string)
-	dc, err := getDC(d, client)
+	dc, err := getDC(d, client, meta)
 	if err != nil {
 		return err
 	}

--- a/consul/resource_consul_key_prefix_test.go
+++ b/consul/resource_consul_key_prefix_test.go
@@ -64,7 +64,11 @@ func TestAccConsulKeyPrefix_basic(t *testing.T) {
 }
 
 func testAccCheckConsulKeyPrefixDestroy(s *terraform.State) error {
-	kv := testAccProvider.Meta().(*consulapi.Client).KV()
+	client, err := testAccProvider.Meta().(*Config).Client()
+	if err != nil {
+		return err
+	}
+	kv := client.KV()
 	opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 	pair, _, err := kv.Get("test/set", opts)
 	if err != nil {
@@ -79,7 +83,11 @@ func testAccCheckConsulKeyPrefixDestroy(s *terraform.State) error {
 func testAccCheckConsulKeyPrefixKeyAbsent(name string) resource.TestCheckFunc {
 	fullName := "prefix_test/" + name
 	return func(s *terraform.State) error {
-		kv := testAccProvider.Meta().(*consulapi.Client).KV()
+		client, err := testAccProvider.Meta().(*Config).Client()
+		if err != nil {
+			return err
+		}
+		kv := client.KV()
 		opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 		pair, _, err := kv.Get(fullName, opts)
 		if err != nil {
@@ -97,13 +105,17 @@ func testAccCheckConsulKeyPrefixKeyAbsent(name string) resource.TestCheckFunc {
 func testAccAddConsulKeyPrefixRogue(name, value string) resource.TestCheckFunc {
 	fullName := "prefix_test/" + name
 	return func(s *terraform.State) error {
-		kv := testAccProvider.Meta().(*consulapi.Client).KV()
+		client, err := testAccProvider.Meta().(*Config).Client()
+		if err != nil {
+			return err
+		}
+		kv := client.KV()
 		opts := &consulapi.WriteOptions{Datacenter: "dc1"}
 		pair := &consulapi.KVPair{
 			Key:   fullName,
 			Value: []byte(value),
 		}
-		_, err := kv.Put(pair, opts)
+		_, err = kv.Put(pair, opts)
 		return err
 	}
 }
@@ -111,7 +123,11 @@ func testAccAddConsulKeyPrefixRogue(name, value string) resource.TestCheckFunc {
 func testAccCheckConsulKeyPrefixKeyValue(name, value string, flags uint64) resource.TestCheckFunc {
 	fullName := "prefix_test/" + name
 	return func(s *terraform.State) error {
-		kv := testAccProvider.Meta().(*consulapi.Client).KV()
+		client, err := testAccProvider.Meta().(*Config).Client()
+		if err != nil {
+			return err
+		}
+		kv := client.KV()
 		opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 		pair, _, err := kv.Get(fullName, opts)
 		if err != nil {

--- a/consul/resource_consul_key_prefix_test.go
+++ b/consul/resource_consul_key_prefix_test.go
@@ -64,10 +64,7 @@ func TestAccConsulKeyPrefix_basic(t *testing.T) {
 }
 
 func testAccCheckConsulKeyPrefixDestroy(s *terraform.State) error {
-	client, err := testAccProvider.Meta().(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(testAccProvider.Meta())
 	kv := client.KV()
 	opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 	pair, _, err := kv.Get("test/set", opts)
@@ -83,10 +80,7 @@ func testAccCheckConsulKeyPrefixDestroy(s *terraform.State) error {
 func testAccCheckConsulKeyPrefixKeyAbsent(name string) resource.TestCheckFunc {
 	fullName := "prefix_test/" + name
 	return func(s *terraform.State) error {
-		client, err := testAccProvider.Meta().(*Config).Client()
-		if err != nil {
-			return err
-		}
+		client := getClient(testAccProvider.Meta())
 		kv := client.KV()
 		opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 		pair, _, err := kv.Get(fullName, opts)
@@ -105,17 +99,14 @@ func testAccCheckConsulKeyPrefixKeyAbsent(name string) resource.TestCheckFunc {
 func testAccAddConsulKeyPrefixRogue(name, value string) resource.TestCheckFunc {
 	fullName := "prefix_test/" + name
 	return func(s *terraform.State) error {
-		client, err := testAccProvider.Meta().(*Config).Client()
-		if err != nil {
-			return err
-		}
+		client := getClient(testAccProvider.Meta())
 		kv := client.KV()
 		opts := &consulapi.WriteOptions{Datacenter: "dc1"}
 		pair := &consulapi.KVPair{
 			Key:   fullName,
 			Value: []byte(value),
 		}
-		_, err = kv.Put(pair, opts)
+		_, err := kv.Put(pair, opts)
 		return err
 	}
 }
@@ -123,10 +114,7 @@ func testAccAddConsulKeyPrefixRogue(name, value string) resource.TestCheckFunc {
 func testAccCheckConsulKeyPrefixKeyValue(name, value string, flags uint64) resource.TestCheckFunc {
 	fullName := "prefix_test/" + name
 	return func(s *terraform.State) error {
-		client, err := testAccProvider.Meta().(*Config).Client()
-		if err != nil {
-			return err
-		}
+		client := getClient(testAccProvider.Meta())
 		kv := client.KV()
 		opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 		pair, _, err := kv.Get(fullName, opts)

--- a/consul/resource_consul_keys.go
+++ b/consul/resource_consul_keys.go
@@ -83,10 +83,7 @@ func resourceConsulKeys() *schema.Resource {
 }
 
 func resourceConsulKeysCreate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	kv := client.KV()
 	token := d.Get("token").(string)
 	dc, err := getDC(d, client, meta)
@@ -124,10 +121,7 @@ func resourceConsulKeysCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceConsulKeysUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	kv := client.KV()
 	token := d.Get("token").(string)
 	dc, err := getDC(d, client, meta)
@@ -213,10 +207,7 @@ func resourceConsulKeysUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceConsulKeysRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	kv := client.KV()
 	token := d.Get("token").(string)
 	dc, err := getDC(d, client, meta)
@@ -276,10 +267,7 @@ func resourceConsulKeysRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceConsulKeysDelete(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	kv := client.KV()
 	token := d.Get("token").(string)
 	dc, err := getDC(d, client, meta)

--- a/consul/resource_consul_keys_test.go
+++ b/consul/resource_consul_keys_test.go
@@ -57,10 +57,7 @@ func testAccCheckConsulKeysFlags(path string, flags int) resource.TestCheckFunc 
 }
 
 func testAccCheckConsulKeysDestroy(s *terraform.State) error {
-	client, err := testAccProvider.Meta().(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(testAccProvider.Meta())
 	kv := client.KV()
 	opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 	pair, _, err := kv.Get("test/set", opts)
@@ -75,10 +72,7 @@ func testAccCheckConsulKeysDestroy(s *terraform.State) error {
 
 func testAccCheckConsulKeysExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client, err := testAccProvider.Meta().(*Config).Client()
-		if err != nil {
-			return err
-		}
+		client := getClient(testAccProvider.Meta())
 		kv := client.KV()
 		opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 		pair, _, err := kv.Get("test/set", opts)

--- a/consul/resource_consul_keys_test.go
+++ b/consul/resource_consul_keys_test.go
@@ -57,7 +57,11 @@ func testAccCheckConsulKeysFlags(path string, flags int) resource.TestCheckFunc 
 }
 
 func testAccCheckConsulKeysDestroy(s *terraform.State) error {
-	kv := testAccProvider.Meta().(*consulapi.Client).KV()
+	client, err := testAccProvider.Meta().(*Config).Client()
+	if err != nil {
+		return err
+	}
+	kv := client.KV()
 	opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 	pair, _, err := kv.Get("test/set", opts)
 	if err != nil {
@@ -71,7 +75,11 @@ func testAccCheckConsulKeysDestroy(s *terraform.State) error {
 
 func testAccCheckConsulKeysExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		kv := testAccProvider.Meta().(*consulapi.Client).KV()
+		client, err := testAccProvider.Meta().(*Config).Client()
+		if err != nil {
+			return err
+		}
+		kv := client.KV()
 		opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 		pair, _, err := kv.Get("test/set", opts)
 		if err != nil {

--- a/consul/resource_consul_node.go
+++ b/consul/resource_consul_node.go
@@ -50,10 +50,7 @@ func resourceConsulNode() *schema.Resource {
 }
 
 func resourceConsulNodeCreate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	catalog := client.Catalog()
 
 	var dc string
@@ -111,10 +108,7 @@ func resourceConsulNodeCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceConsulNodeRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	catalog := client.Catalog()
 
 	// Get the DC, error if not available.
@@ -141,10 +135,7 @@ func resourceConsulNodeRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceConsulNodeDelete(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	catalog := client.Catalog()
 
 	var dc string

--- a/consul/resource_consul_node.go
+++ b/consul/resource_consul_node.go
@@ -50,7 +50,10 @@ func resourceConsulNode() *schema.Resource {
 }
 
 func resourceConsulNodeCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	catalog := client.Catalog()
 
 	var dc string
@@ -58,7 +61,7 @@ func resourceConsulNodeCreate(d *schema.ResourceData, meta interface{}) error {
 		dc = v.(string)
 	} else {
 		var err error
-		if dc, err = getDC(d, client); err != nil {
+		if dc, err = getDC(d, client, meta); err != nil {
 			return err
 		}
 	}
@@ -108,7 +111,10 @@ func resourceConsulNodeCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceConsulNodeRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	catalog := client.Catalog()
 
 	// Get the DC, error if not available.
@@ -135,7 +141,10 @@ func resourceConsulNodeRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceConsulNodeDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	catalog := client.Catalog()
 
 	var dc string
@@ -143,7 +152,7 @@ func resourceConsulNodeDelete(d *schema.ResourceData, meta interface{}) error {
 		dc = v.(string)
 	} else {
 		var err error
-		if dc, err = getDC(d, client); err != nil {
+		if dc, err = getDC(d, client, meta); err != nil {
 			return err
 		}
 	}

--- a/consul/resource_consul_node_test.go
+++ b/consul/resource_consul_node_test.go
@@ -71,10 +71,7 @@ func TestAccConsulNode_nodeMeta(t *testing.T) {
 }
 
 func testAccCheckConsulNodeDestroy(s *terraform.State) error {
-	client, err := testAccProvider.Meta().(*Config).Client()
-	if err != nil {
-		return nil
-	}
+	client := getClient(testAccProvider.Meta())
 	catalog := client.Catalog()
 	qOpts := consulapi.QueryOptions{}
 	nodes, _, err := catalog.Nodes(&qOpts)
@@ -91,10 +88,7 @@ func testAccCheckConsulNodeDestroy(s *terraform.State) error {
 
 func testAccCheckConsulNodeExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client, err := testAccProvider.Meta().(*Config).Client()
-		if err != nil {
-			return nil
-		}
+		client := getClient(testAccProvider.Meta())
 		catalog := client.Catalog()
 		qOpts := consulapi.QueryOptions{}
 		nodes, _, err := catalog.Nodes(&qOpts)
@@ -146,16 +140,13 @@ func testAccCheckConsulNodeValueRemoved(n, attr string) resource.TestCheckFunc {
 
 func testAccRemoveConsulNode(t *testing.T) func() {
 	return func() {
-		client, err := testAccProvider.Meta().(*Config).Client()
-		if err != nil {
-			t.Fatal(err)
-		}
+		client := getClient(testAccProvider.Meta())
 		catalog := client.Catalog()
 		wOpts := &consulapi.WriteOptions{}
 		dereg := &consulapi.CatalogDeregistration{
 			Node: "foo",
 		}
-		_, err = catalog.Deregister(dereg, wOpts)
+		_, err := catalog.Deregister(dereg, wOpts)
 		if err != nil {
 			t.Errorf("err: %v", err)
 		}

--- a/consul/resource_consul_node_test.go
+++ b/consul/resource_consul_node_test.go
@@ -71,7 +71,11 @@ func TestAccConsulNode_nodeMeta(t *testing.T) {
 }
 
 func testAccCheckConsulNodeDestroy(s *terraform.State) error {
-	catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
+	client, err := testAccProvider.Meta().(*Config).Client()
+	if err != nil {
+		return nil
+	}
+	catalog := client.Catalog()
 	qOpts := consulapi.QueryOptions{}
 	nodes, _, err := catalog.Nodes(&qOpts)
 	if err != nil {
@@ -87,7 +91,11 @@ func testAccCheckConsulNodeDestroy(s *terraform.State) error {
 
 func testAccCheckConsulNodeExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
+		client, err := testAccProvider.Meta().(*Config).Client()
+		if err != nil {
+			return nil
+		}
+		catalog := client.Catalog()
 		qOpts := consulapi.QueryOptions{}
 		nodes, _, err := catalog.Nodes(&qOpts)
 		if err != nil {
@@ -138,12 +146,16 @@ func testAccCheckConsulNodeValueRemoved(n, attr string) resource.TestCheckFunc {
 
 func testAccRemoveConsulNode(t *testing.T) func() {
 	return func() {
-		catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
+		client, err := testAccProvider.Meta().(*Config).Client()
+		if err != nil {
+			t.Fatal(err)
+		}
+		catalog := client.Catalog()
 		wOpts := &consulapi.WriteOptions{}
 		dereg := &consulapi.CatalogDeregistration{
 			Node: "foo",
 		}
-		_, err := catalog.Deregister(dereg, wOpts)
+		_, err = catalog.Deregister(dereg, wOpts)
 		if err != nil {
 			t.Errorf("err: %v", err)
 		}

--- a/consul/resource_consul_prepared_query.go
+++ b/consul/resource_consul_prepared_query.go
@@ -122,10 +122,7 @@ func resourceConsulPreparedQuery() *schema.Resource {
 }
 
 func resourceConsulPreparedQueryCreate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	wo := &consulapi.WriteOptions{
 		Datacenter: d.Get("datacenter").(string),
 		Token:      d.Get("token").(string),
@@ -143,10 +140,7 @@ func resourceConsulPreparedQueryCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceConsulPreparedQueryUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	wo := &consulapi.WriteOptions{
 		Datacenter: d.Get("datacenter").(string),
 		Token:      d.Get("token").(string),
@@ -162,10 +156,7 @@ func resourceConsulPreparedQueryUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceConsulPreparedQueryRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	qo := &consulapi.QueryOptions{
 		Datacenter: d.Get("datacenter").(string),
 		Token:      d.Get("token").(string),
@@ -215,10 +206,7 @@ func resourceConsulPreparedQueryRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceConsulPreparedQueryDelete(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	writeOpts := &consulapi.WriteOptions{
 		Datacenter: d.Get("datacenter").(string),
 		Token:      d.Get("token").(string),

--- a/consul/resource_consul_prepared_query.go
+++ b/consul/resource_consul_prepared_query.go
@@ -122,7 +122,10 @@ func resourceConsulPreparedQuery() *schema.Resource {
 }
 
 func resourceConsulPreparedQueryCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	wo := &consulapi.WriteOptions{
 		Datacenter: d.Get("datacenter").(string),
 		Token:      d.Get("token").(string),
@@ -140,7 +143,10 @@ func resourceConsulPreparedQueryCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceConsulPreparedQueryUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	wo := &consulapi.WriteOptions{
 		Datacenter: d.Get("datacenter").(string),
 		Token:      d.Get("token").(string),
@@ -156,7 +162,10 @@ func resourceConsulPreparedQueryUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceConsulPreparedQueryRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	qo := &consulapi.QueryOptions{
 		Datacenter: d.Get("datacenter").(string),
 		Token:      d.Get("token").(string),
@@ -206,7 +215,10 @@ func resourceConsulPreparedQueryRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceConsulPreparedQueryDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	writeOpts := &consulapi.WriteOptions{
 		Datacenter: d.Get("datacenter").(string),
 		Token:      d.Get("token").(string),

--- a/consul/resource_consul_prepared_query_test.go
+++ b/consul/resource_consul_prepared_query_test.go
@@ -106,10 +106,7 @@ func checkPreparedQueryExists(s *terraform.State) bool {
 	}
 	id := rn.Primary.ID
 
-	c, err := testAccProvider.Meta().(*Config).Client()
-	if err != nil {
-		return false
-	}
+	c := getClient(testAccProvider.Meta())
 	client := c.PreparedQuery()
 	opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 	pq, _, err := client.Get(id, opts)

--- a/consul/resource_consul_prepared_query_test.go
+++ b/consul/resource_consul_prepared_query_test.go
@@ -106,7 +106,11 @@ func checkPreparedQueryExists(s *terraform.State) bool {
 	}
 	id := rn.Primary.ID
 
-	client := testAccProvider.Meta().(*consulapi.Client).PreparedQuery()
+	c, err := testAccProvider.Meta().(*Config).Client()
+	if err != nil {
+		return false
+	}
+	client := c.PreparedQuery()
 	opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 	pq, _, err := client.Get(id, opts)
 	return err == nil && pq != nil

--- a/consul/resource_consul_service.go
+++ b/consul/resource_consul_service.go
@@ -167,10 +167,7 @@ func resourceConsulService() *schema.Resource {
 }
 
 func resourceConsulServiceCreate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	catalog := client.Catalog()
 
 	name := d.Get("name").(string)
@@ -273,11 +270,7 @@ func resourceConsulServiceCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceConsulServiceUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
-	catalog := client.Catalog()
+	catalog := getClient(meta).Catalog()
 
 	name := d.Get("name").(string)
 	node := d.Get("node").(string)
@@ -349,10 +342,7 @@ func resourceConsulServiceUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceConsulServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 
 	dc := ""
 	if _, ok := d.GetOk("datacenter"); ok {
@@ -452,10 +442,7 @@ func resourceConsulServiceRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceConsulServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return err
-	}
+	client := getClient(meta)
 	catalog := client.Catalog()
 	id := d.Id()
 	node := d.Get("node").(string)

--- a/consul/resource_consul_service.go
+++ b/consul/resource_consul_service.go
@@ -167,7 +167,10 @@ func resourceConsulService() *schema.Resource {
 }
 
 func resourceConsulServiceCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	catalog := client.Catalog()
 
 	name := d.Get("name").(string)
@@ -270,7 +273,10 @@ func resourceConsulServiceCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceConsulServiceUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	catalog := client.Catalog()
 
 	name := d.Get("name").(string)
@@ -343,7 +349,10 @@ func resourceConsulServiceUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceConsulServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	dc := ""
 	if _, ok := d.GetOk("datacenter"); ok {
@@ -443,7 +452,10 @@ func resourceConsulServiceRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceConsulServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*consulapi.Client)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 	catalog := client.Catalog()
 	id := d.Id()
 	node := d.Get("node").(string)

--- a/consul/resource_consul_service_test.go
+++ b/consul/resource_consul_service_test.go
@@ -150,10 +150,7 @@ func TestAccConsulService_nodeDoesNotExist(t *testing.T) {
 }
 
 func testAccConsulExternalSource(s *terraform.State) error {
-	client, err := testAccProvider.Meta().(*Config).Client()
-	if err != nil {
-		return nil
-	}
+	client := getClient(testAccProvider.Meta())
 	qOpts := consulapi.QueryOptions{}
 
 	service, _, err := client.Catalog().Service("example", "", &qOpts)
@@ -171,11 +168,7 @@ func testAccConsulExternalSource(s *terraform.State) error {
 }
 
 func testAccCheckConsulServiceDestroy(s *terraform.State) error {
-	client, err := testAccProvider.Meta().(*Config).Client()
-	if err != nil {
-		return nil
-	}
-
+	client := getClient(testAccProvider.Meta())
 	qOpts := consulapi.QueryOptions{}
 	services, _, err := client.Catalog().Services(&qOpts)
 	if err != nil {
@@ -191,17 +184,14 @@ func testAccCheckConsulServiceDestroy(s *terraform.State) error {
 
 func testAccRemoveConsulService(t *testing.T) func() {
 	return func() {
-		client, err := testAccProvider.Meta().(*Config).Client()
-		if err != nil {
-			t.Fatal(err)
-		}
+		client := getClient(testAccProvider.Meta())
 		catalog := client.Catalog()
 		wOpts := &consulapi.WriteOptions{}
 		dereg := &consulapi.CatalogDeregistration{
 			Node:      "compute-example",
 			ServiceID: "example",
 		}
-		_, err = catalog.Deregister(dereg, wOpts)
+		_, err := catalog.Deregister(dereg, wOpts)
 		if err != nil {
 			t.Errorf("err: %v", err)
 		}

--- a/consul/resource_consul_service_test.go
+++ b/consul/resource_consul_service_test.go
@@ -150,7 +150,10 @@ func TestAccConsulService_nodeDoesNotExist(t *testing.T) {
 }
 
 func testAccConsulExternalSource(s *terraform.State) error {
-	client := testAccProvider.Meta().(*consulapi.Client)
+	client, err := testAccProvider.Meta().(*Config).Client()
+	if err != nil {
+		return nil
+	}
 	qOpts := consulapi.QueryOptions{}
 
 	service, _, err := client.Catalog().Service("example", "", &qOpts)
@@ -168,7 +171,10 @@ func testAccConsulExternalSource(s *terraform.State) error {
 }
 
 func testAccCheckConsulServiceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*consulapi.Client)
+	client, err := testAccProvider.Meta().(*Config).Client()
+	if err != nil {
+		return nil
+	}
 
 	qOpts := consulapi.QueryOptions{}
 	services, _, err := client.Catalog().Services(&qOpts)
@@ -185,13 +191,17 @@ func testAccCheckConsulServiceDestroy(s *terraform.State) error {
 
 func testAccRemoveConsulService(t *testing.T) func() {
 	return func() {
-		catalog := testAccProvider.Meta().(*consulapi.Client).Catalog()
+		client, err := testAccProvider.Meta().(*Config).Client()
+		if err != nil {
+			t.Fatal(err)
+		}
+		catalog := client.Catalog()
 		wOpts := &consulapi.WriteOptions{}
 		dereg := &consulapi.CatalogDeregistration{
 			Node:      "compute-example",
 			ServiceID: "example",
 		}
-		_, err := catalog.Deregister(dereg, wOpts)
+		_, err = catalog.Deregister(dereg, wOpts)
 		if err != nil {
 			t.Errorf("err: %v", err)
 		}

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -118,11 +118,16 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	var config Config
+	var config *Config
 	configRaw := d.Get("").(map[string]interface{})
 	if err := mapstructure.Decode(configRaw, &config); err != nil {
 		return nil, err
 	}
 	log.Printf("[INFO] Initializing Consul client")
-	return config.Client()
+	if _, err := config.Client(); err != nil {
+		// The provider must error if the configuration is incorrect. We must
+		// check this here.
+		return nil, err
+	}
+	return config, nil
 }

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"log"
 
+	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/mapstructure"
@@ -130,4 +131,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, err
 	}
 	return config, nil
+}
+
+func getClient(meta interface{}) *consulapi.Client {
+	// We can ignore err since we checked the configuration in providerConfigure()
+	client, _ := meta.(*Config).Client()
+	return client
 }

--- a/website/docs/d/autopilot_health.html.markdown
+++ b/website/docs/d/autopilot_health.html.markdown
@@ -26,8 +26,8 @@ output "health" {
 
 The following arguments are supported:
 
-* `datacenter` - (Optional) The datacenter to use. This overrides the
-  datacenter in the provider setup and the agent's default datacenter.
+* `datacenter` - (Optional) The datacenter to use. This overrides the agent's
+  default datacenter and the datacenter in the provider setup.
 
 ## Attributes Reference
 

--- a/website/docs/d/key_prefix.html.markdown
+++ b/website/docs/d/key_prefix.html.markdown
@@ -60,7 +60,7 @@ resource "aws_instance" "web" {
 The following arguments are supported:
 
 * `datacenter` - (Optional) The datacenter to use. This overrides the
-  datacenter in the provider setup and the agent's default datacenter.
+  agent's default datacenter and the datacenter in the provider setup.
 
 * `token` - (Optional) The ACL token to use. This overrides the
   token that the agent provides by default.

--- a/website/docs/d/keys.html.markdown
+++ b/website/docs/d/keys.html.markdown
@@ -39,7 +39,7 @@ resource "aws_instance" "app" {
 The following arguments are supported:
 
 * `datacenter` - (Optional) The datacenter to use. This overrides the
-  datacenter in the provider setup and the agent's default datacenter.
+  agent's default datacenter and the datacenter in the provider setup.
 
 * `token` - (Optional) The ACL token to use. This overrides the
   token that the agent provides by default.

--- a/website/docs/d/nodes.html.markdown
+++ b/website/docs/d/nodes.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 * `datacenter` - (Optional) The Consul datacenter to query.  Defaults to the
   same value found in `query_options` parameter specified below, or if that is
   empty, the `datacenter` value found in the Consul agent that this provider is
-  configured to talk to.
+  configured to talk to then the datacenter in the provider setup.
 
 * `query_options` - (Optional) See below.
 

--- a/website/docs/r/autopilot_config.html.markdown
+++ b/website/docs/r/autopilot_config.html.markdown
@@ -28,8 +28,8 @@ resource "consul_autopilot_config" "config" {
 
 The following arguments are supported:
 
-* `datacenter` - (Optional) The datacenter to use. This overrides the
-  datacenter in the provider setup and the agent's default datacenter.
+* `datacenter` - (Optional) The datacenter to use. This overrides the agent's
+  default datacenter and the datacenter in the provider setup.
 
 * `cleanup_dead_servers` - (Optional) Whether to remove failing servers when a
 replacement comes online. Defaults to true.

--- a/website/docs/r/catalog_entry.html.markdown
+++ b/website/docs/r/catalog_entry.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
   the node. Supported values are documented below.
 
 * `datacenter` - (Optional) The datacenter to use. This overrides the
-  datacenter in the provider setup and the agent's default datacenter.
+  agent's default datacenter and the datacenter in the provider setup.
 
 * `token` - (Optional) ACL token.
 

--- a/website/docs/r/intention.html.markdown
+++ b/website/docs/r/intention.html.markdown
@@ -60,8 +60,8 @@ with the intention.
 * `description` - (Optional, string) Optional description that can be used by Consul
 tooling, but is not used internally.
 
-* `datacenter` - (Optional) The datacenter to use. This overrides the datacenter in the
-provider setup and the agent's default datacenter.
+* `datacenter` - (Optional) The datacenter to use. This overrides the
+  agent's default datacenter and the datacenter in the provider setup.
 
 ## Attributes Reference
 

--- a/website/docs/r/key_prefix.html.markdown
+++ b/website/docs/r/key_prefix.html.markdown
@@ -65,7 +65,7 @@ resource "consul_key_prefix" "myapp_config" {
 The following arguments are supported:
 
 * `datacenter` - (Optional) The datacenter to use. This overrides the
-  datacenter in the provider setup and the agent's default datacenter.
+  agent's default datacenter and the datacenter in the provider setup.
 
 * `token` - (Optional) The ACL token to use. This overrides the
   token that the agent provides by default.

--- a/website/docs/r/keys.html.markdown
+++ b/website/docs/r/keys.html.markdown
@@ -38,7 +38,7 @@ resource "consul_keys" "app" {
 The following arguments are supported:
 
 * `datacenter` - (Optional) The datacenter to use. This overrides the
-  datacenter in the provider setup and the agent's default datacenter.
+  agent's default datacenter and the datacenter in the provider setup.
 
 * `token` - (Optional) The ACL token to use. This overrides the
   token that the agent provides by default.

--- a/website/docs/r/node.html.markdown
+++ b/website/docs/r/node.html.markdown
@@ -30,7 +30,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the node being added to, or
   referenced in the catalog.
 
-* `datacenter` - (Optional) The datacenter to use. Defaults to that of the agent.
+* `datacenter` - (Optional) The datacenter to use. This overrides the agent's
+  default datacenter and the datacenter in the provider setup.
 
 * `meta` - (Optional, map) Key/value pairs that are associated with the node.
 

--- a/website/docs/r/prepared_query.markdown
+++ b/website/docs/r/prepared_query.markdown
@@ -75,7 +75,7 @@ resource "consul_prepared_query" "service-near-self" {
 The following arguments are supported:
 
 * `datacenter` - (Optional) The datacenter to use. This overrides the
-  datacenter in the provider setup and the agent's default datacenter.
+  agent's default datacenter and the datacenter in the provider setup.
 
 * `token` - (Optional) The ACL token to use when saving the prepared query.
   This overrides the token that the agent provides by default.

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -101,8 +101,8 @@ of the `name` attribute.
 * `tags` - (Optional, set of strings) A list of values that are opaque to Consul,
   but can be used to distinguish between services or nodes.
 
-* `datacenter` - (Optional) The datacenter to use. This overrides the datacenter in the
-provider setup and the agent's default datacenter.
+* `datacenter` - (Optional) The datacenter to use. This overrides the
+  agent's default datacenter and the datacenter in the provider setup.
 
 
 The following attributes are available for each health-check:


### PR DESCRIPTION
According to the current documentation, the datacenter attribute should
default to the provider configuration and if it is not set to the
datacenter of the agent terraform is connected to:

	* `datacenter` - (Optional) The datacenter to use. This overrides the datacenter in the
	  provider setup and the agent's default datacenter.

This is not what the code actually does and the datacenter in the provider
configuration is not used most of the time.

Since changing the plugin behavior to what is actually documented may
break code relying on the current one. To keep backward compatibility,
we can change the documentation to:

	* `datacenter` - (Optional) The datacenter to use. This overrides the
	  agent's default datacenter and the datacenter in the provider setup.

and fall back to the provider configuration only when the datacenter of
the agent to which terraform is connected to can not be read (when ACL
is enabled and the token used by terraform does not have permission to
read /agent/self for example).

The change is very noisy as it requires to change the `ConfigureFunc` of
the provider from `(*consulapi.Client, error)` to `(*Config, error)` and
update all places where was being used.

The interesting change is at https://github.com/terraform-providers/terraform-provider-consul/pull/105/files#diff-7c162fe0d0220927a53a0f1977a47a71R361

Discussion: https://github.com/terraform-providers/terraform-provider-consul/issues/57