### PR TITLE
Add Consul Connect support to prepared queries.

### DIFF
--- a/consul/resource_consul_prepared_query.go
+++ b/consul/resource_consul_prepared_query.go
@@ -67,6 +67,11 @@ func resourceConsulPreparedQuery() *schema.Resource {
 				Optional: true,
 			},
 
+			"connect": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"failover": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -184,6 +189,7 @@ func resourceConsulPreparedQueryRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("service", pq.Service.Service)
 	d.Set("near", pq.Service.Near)
 	d.Set("only_passing", pq.Service.OnlyPassing)
+	d.Set("connect", pq.Service.Connect)
 	d.Set("tags", pq.Service.Tags)
 
 	if pq.Service.Failover.NearestN > 0 {
@@ -230,6 +236,7 @@ func preparedQueryDefinitionFromResourceData(d *schema.ResourceData) *consulapi.
 			Service:     d.Get("service").(string),
 			Near:        d.Get("near").(string),
 			OnlyPassing: d.Get("only_passing").(bool),
+			Connect:     d.Get("connect").(bool),
 		},
 	}
 

--- a/consul/resource_consul_prepared_query_test.go
+++ b/consul/resource_consul_prepared_query_test.go
@@ -25,6 +25,7 @@ func TestAccConsulPreparedQuery_basic(t *testing.T) {
 					testAccCheckConsulPreparedQueryAttrValue("near", "_agent"),
 					testAccCheckConsulPreparedQueryAttrValue("tags.#", "1"),
 					testAccCheckConsulPreparedQueryAttrValue("only_passing", "true"),
+					testAccCheckConsulPreparedQueryAttrValue("connect", "false"),
 					testAccCheckConsulPreparedQueryAttrValue("failover.0.nearest_n", "3"),
 					testAccCheckConsulPreparedQueryAttrValue("failover.0.datacenters.#", "2"),
 					testAccCheckConsulPreparedQueryAttrValue("template.0.type", "name_prefix_match"),
@@ -42,6 +43,7 @@ func TestAccConsulPreparedQuery_basic(t *testing.T) {
 					testAccCheckConsulPreparedQueryAttrValue("near", "node1"),
 					testAccCheckConsulPreparedQueryAttrValue("tags.#", "2"),
 					testAccCheckConsulPreparedQueryAttrValue("only_passing", "false"),
+					testAccCheckConsulPreparedQueryAttrValue("connect", "true"),
 					testAccCheckConsulPreparedQueryAttrValue("failover.0.nearest_n", "2"),
 					testAccCheckConsulPreparedQueryAttrValue("failover.0.datacenters.#", "1"),
 					testAccCheckConsulPreparedQueryAttrValue("template.0.regexp", "goodbye"),
@@ -153,6 +155,7 @@ resource "consul_prepared_query" "foo" {
 	tags = ["prod"]
 	near = "_agent"
 	only_passing = true
+	connect = false
 
 	failover {
 		nearest_n = 3
@@ -178,6 +181,7 @@ resource "consul_prepared_query" "foo" {
 	tags = ["prod","sup"]
 	near = "node1"
 	only_passing = false
+	connect = true
 
 	failover {
 		nearest_n = 2

--- a/consul/resource_consul_prepared_query_test.go
+++ b/consul/resource_consul_prepared_query_test.go
@@ -155,7 +155,6 @@ resource "consul_prepared_query" "foo" {
 	tags = ["prod"]
 	near = "_agent"
 	only_passing = true
-	connect = false
 
 	failover {
 		nearest_n = 3

--- a/website/docs/r/prepared_query.markdown
+++ b/website/docs/r/prepared_query.markdown
@@ -50,6 +50,7 @@ resource "consul_prepared_query" "service-near-self" {
   stored_token = "wxyz"
   name         = ""
   only_passing = true
+  connect      = true
   near         = "_agent"
 
   template {
@@ -101,6 +102,10 @@ The following arguments are supported:
 
 * `only_passing` - (Optional) When `true`, the prepared query will only
   return nodes with passing health checks in the result.
+
+*  `connect` - (Optional) When `true` the prepared query will return connect
+  proxy services for a queried service.  Conditions such as `tags` in the
+  prepared query will be matched against the proxy service.
 
 * `near` - (Optional) Allows specifying the name of a node to sort results
   near using Consul's distance sorting and network coordinates. The magic

--- a/website/docs/r/prepared_query.markdown
+++ b/website/docs/r/prepared_query.markdown
@@ -105,7 +105,7 @@ The following arguments are supported:
 
 *  `connect` - (Optional) When `true` the prepared query will return connect
   proxy services for a queried service.  Conditions such as `tags` in the
-  prepared query will be matched against the proxy service.
+  prepared query will be matched against the proxy service. Defaults to false.
 
 * `near` - (Optional) Allows specifying the name of a node to sort results
   near using Consul's distance sorting and network coordinates. The magic


### PR DESCRIPTION
Quick add for querying for Consul Connect sidecars in prepared queries.  Probably needs a test but wanted to see if anything else might be needed as well.  Thanks!