### PR TITLE
Export token secret and add ability to specify dc/token for ACL provisioning

### DIFF
--- a/consul/request_options.go
+++ b/consul/request_options.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	consulapi "github.com/hashicorp/consul/api"
@@ -65,8 +64,6 @@ func getRequestOpts(d *schema.ResourceData, client *consulapi.Client) (*consulap
 		requestOpts.Datacenter = dc
 		queryOpts.Datacenter = dc
 	}
-
-	log.Printf("[DEBUG] Options %+v %+v", d, requestOpts)
 
 	return requestOpts, queryOpts, nil
 }

--- a/consul/request_options.go
+++ b/consul/request_options.go
@@ -1,0 +1,85 @@
+package consul
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+const (
+	requestOptions = "request_options"
+
+	requestOptDatacenter = "datacenter"
+	requestOptToken      = "token"
+)
+
+var schemaRequestOpts = &schema.Schema{
+	Optional: true,
+	Type:     schema.TypeSet,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			requestOptDatacenter: {
+				// Optional because we'll pull the default from the local agent if it's
+				// not specified, but we can query remote data centers as a result.
+				Optional: true,
+				Type:     schema.TypeString,
+			},
+			requestOptToken: {
+				Optional:  true,
+				Type:      schema.TypeString,
+				Sensitive: true,
+			},
+		},
+	},
+}
+
+func getRequestOpts(d *schema.ResourceData, client *consulapi.Client) (*consulapi.WriteOptions, *consulapi.QueryOptions, error) {
+	requestOpts := &consulapi.WriteOptions{}
+	queryOpts := &consulapi.QueryOptions{}
+
+	if v, ok := d.GetOk(requestOptions); ok {
+		options := v.(*schema.Set).List()
+		if len(options) > 0 {
+			opts := options[0].(map[string]interface{})
+
+			if token, ok := opts[requestOptToken]; ok {
+				requestOpts.Token = token.(string)
+				queryOpts.Token = token.(string)
+			}
+
+			if dc, ok := opts[requestOptDatacenter]; ok {
+				requestOpts.Datacenter = dc.(string)
+				queryOpts.Datacenter = dc.(string)
+			}
+		}
+	}
+
+	if requestOpts.Datacenter == "" {
+		dc, err := getLocalDC(client)
+		if err != nil {
+			return nil, nil, err
+		}
+		requestOpts.Datacenter = dc
+		queryOpts.Datacenter = dc
+	}
+
+	log.Printf("[DEBUG] Options %+v %+v", d, requestOpts)
+
+	return requestOpts, queryOpts, nil
+}
+
+func getLocalDC(client *consulapi.Client) (string, error) {
+	info, err := client.Agent().Self()
+	if err != nil {
+		// Reading can fail with `Unexpected response code: 403 (Permission denied)`
+		// if the permission has not been given. Default to "" in this case.
+		if strings.HasSuffix(err.Error(), "403 (Permission denied)") {
+			return "", nil
+		}
+		return "", fmt.Errorf("Failed to get datacenter from Consul agent: %v", err)
+	}
+	return info["Config"]["Datacenter"].(string), nil
+}

--- a/consul/resource_consul_acl_token.go
+++ b/consul/resource_consul_acl_token.go
@@ -13,7 +13,6 @@ const (
 	resourceACLTokenDescription = "description"
 	resourceACLTokenPolicies    = "policies"
 	resourceACLTokenLocal       = "local"
-	resourceACLTokenRequestOpts = "request_options"
 
 	resourceACLTokenSecret = "secret"
 )
@@ -48,8 +47,9 @@ func resourceConsulACLToken() *schema.Resource {
 				Description: "Flag to set the token local to the current datacenter.",
 			},
 			resourceACLTokenSecret: {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 		},
 	}

--- a/consul/resource_consul_acl_token_test.go
+++ b/consul/resource_consul_acl_token_test.go
@@ -41,23 +41,37 @@ func TestAccConsulACLToken_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("consul_acl_token.test", "local", "true"),
 				),
 			},
-			{
-				Config:  testResourceACLTokenConfigBasic,
-				Destroy: false,
-			},
 		},
 	})
 }
 
 const testResourceACLTokenConfigBasic = `
+resource "consul_acl_policy" "write" {
+	name = "test-write"
+	rules = "acl = \"write\""
+	datacenters = [ "dc1" ]
+}
+
+resource "consul_acl_token" "write" {
+	description = "test"
+	policies = ["${consul_acl_policy.write.name}"]
+	local = true
+}
+
 resource "consul_acl_policy" "test" {
 	name = "test"
 	rules = "node \"\" { policy = \"read\" }"
 	datacenters = [ "dc1" ]
+	request_options {
+		token = "${consul_acl_token.write.secret}"
+	}
 }
 
 resource "consul_acl_token" "test" {
 	description = "test"
 	policies = ["${consul_acl_policy.test.name}"]
 	local = true
+	request_options {
+		token = "${consul_acl_token.write.secret}"
+	}
 }`

--- a/website/docs/r/acl_policy.html.markdown
+++ b/website/docs/r/acl_policy.html.markdown
@@ -32,6 +32,17 @@ The following arguments are supported:
 * `description` - (Optional) The description of the policy.
 * `rules` - (Required) The rules of the policy.
 * `datacenters` - (Optional) The datacenters of the policy.
+* `request_options` - (Optional) See below.
+
+The `request_options` block supports the following:
+
+* `datacenter` - (Optional) Specify the Consul Datacenter to use when performing the
+  request.  This defaults to the datacenter local to the `consul` provider configuration
+  but may be overwritten to query a remote datacenter if necessary.
+
+* `token` - (Optional) Specify the Consul ACL token to use when performing the
+  request.  This defaults to the same API token configured by the `consul`
+  provider but may be overriden if necessary.
 
 ## Attributes Reference
 

--- a/website/docs/r/acl_token.html.markdown
+++ b/website/docs/r/acl_token.html.markdown
@@ -36,12 +36,25 @@ The following arguments are supported:
 * `description` - (Optional) The description of the token.
 * `policies` - (Optional) The list of policies attached to the token.
 * `local` - (Optional) The flag to set the token local to the current datacenter.
+* `request_options` - (Optional) See below.
+
+The `request_options` block supports the following:
+
+* `datacenter` - (Optional) Specify the Consul Datacenter to use when performing the
+  request.  This defaults to the datacenter local to the `consul` provider configuration
+  but may be overwritten to query a remote datacenter if necessary.
+
+* `token` - (Optional) Specify the Consul ACL token to use when performing the
+  request.  This defaults to the same API token configured by the `consul`
+  provider but may be overriden if necessary.
+
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The token accessor ID.
+* `secret` - The token secret ID.
 * `description` - The description of the token.
 * `policies` - The list of policies attached to the token.
 * `local` - The flag to set the token local to the current datacenter.


### PR DESCRIPTION
So, I followed form from what I found in `query_options.go` and expanded it to encompass the ability to set `WriteOptions` for the consul api requests. The `getRequestOpts` function differs a good amount from `getQueryOpts` because, as far as I can tell, `getQueryOpts` appears to be broken (it looks like it's always going to have default values in the `QueryOptions` structure due to deserializing `ResourceData` improperly).

~~Also, wasn't sure exactly how acceptance testing was generally done with this repo/who pays attention to it since it appears 1) to be off in CI (no `make testacc` invocation) and 2) to be broken on the docker-compose setup due to the ACL system not being enabled.~~

~~I tested this by adding a configuration file for docker to pick up with ACLs enabled and then ran the acceptance tests. If you want me to try and fix up CI/the testing setup I can, but, as noted, not sure if anyone seems to care about acceptance testing.~~

edit:

re-read the README and saw that the recommended way for acceptance testing is booting up a local consul rather than using the docker-compose stuf