### PR TITLE
added warning so users are aware of the prerequisite

### DIFF
--- a/website/docs/r/acl_policy.html.markdown
+++ b/website/docs/r/acl_policy.html.markdown
@@ -8,9 +8,8 @@ description: |-
 
 # consul_acl_policy
 
-The `consul_acl_policy` resource writes an ACL policy into Consul.
+Starting with Consul 1.4.0, the consul_acl_policy can be used to managed Consul ACL policies.
 
-~> Warning: The consul_acl_policy resource is part of the new policy system introduced in Consul 1.4.0
 
 ## Example Usage
 

--- a/website/docs/r/acl_policy.html.markdown
+++ b/website/docs/r/acl_policy.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 The `consul_acl_policy` resource writes an ACL policy into Consul.
 
+~> Warning: The consul_acl_policy resource is part of the new policy system introduced in Consul 1.4.0
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Adding the supported version to the description prevents users to raise issue if they are using an older version of Consul and Terraform which doesn't provide the feature. 