### PR TITLE
Fix examples in acl_token and acl_policy documentation

### DIFF
--- a/website/docs/r/acl_policy.html.markdown
+++ b/website/docs/r/acl_policy.html.markdown
@@ -16,7 +16,7 @@ The `consul_acl_policy` resource writes an ACL policy into Consul.
 resource "consul_acl_policy" "test" {
   name        = "my_policy"
   datacenters = ["dc1"]
-  rules       = <<RULE
+  rules       = <<-RULE
     node_prefix "" {
       policy = "read"
     }

--- a/website/docs/r/acl_token.html.markdown
+++ b/website/docs/r/acl_token.html.markdown
@@ -15,7 +15,7 @@ The `consul_acl_token` resource writes an ACL token into Consul.
 ```hcl
 resource "consul_acl_policy" "agent" {
   name  = "agent"
-  rules = <<RULE
+  rules = <<-RULE
     node_prefix "" {
       policy = "read"
     }


### PR DESCRIPTION
Let's hope it fixes the website highlighting.

https://www.terraform.io/docs/providers/consul/r/acl_token.html