### PR TITLE
Mark local attribute of consul_acl_token as ForceNew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ BUG FIXES:
 * The `consul_acl_token` resource can now be updated and does not crashes Terraform anymore ([[#102](https://github.com/terraform-providers/terraform-provider-consul/issues/102)])
 * The `consul_node` resource now detect external changes made to its `address` and `meta` attributes ([[#104](https://github.com/terraform-providers/terraform-provider-consul/issues/104)])
 * The `external` attribute of the `consul_service` resource has been deprecated ([[#104](https://github.com/terraform-providers/terraform-provider-consul/issues/104)])
+* The `local` attribute is now correctly marked as requiring the creation of a new ACL token in the `consul_acl_token` resource ([[#117](https://github.com/terraform-providers/terraform-provider-consul/issues/117)])
 
 ## 2.3.0 (April 09, 2019)
 

--- a/consul/resource_consul_acl_token.go
+++ b/consul/resource_consul_acl_token.go
@@ -34,6 +34,7 @@ func resourceConsulACLToken() *schema.Resource {
 			},
 			"local": {
 				Type:        schema.TypeBool,
+				ForceNew:    true,
 				Optional:    true,
 				Default:     false,
 				Description: "Flag to set the token local to the current datacenter.",

--- a/consul/resource_consul_acl_token_test.go
+++ b/consul/resource_consul_acl_token_test.go
@@ -39,7 +39,7 @@ func TestAccConsulACLToken_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("consul_acl_token.test", "description", "test"),
 					resource.TestCheckResourceAttr("consul_acl_token.test", "policies.#", "1"),
 					resource.TestCheckResourceAttr("consul_acl_token.test", "policies.1785148924", "test"),
-					resource.TestCheckResourceAttr("consul_acl_token.test", "local", "true"),
+					resource.TestCheckResourceAttr("consul_acl_token.test", "local", "false"),
 				),
 			},
 			{
@@ -106,7 +106,6 @@ resource "consul_acl_policy" "test" {
 resource "consul_acl_token" "test" {
 	description = "test"
 	policies = ["${consul_acl_policy.test.name}"]
-	local = true
 }`
 
 const testResourceACLTokenConfigUpdate = `

--- a/consul/resource_consul_acl_token_test.go
+++ b/consul/resource_consul_acl_token_test.go
@@ -39,7 +39,7 @@ func TestAccConsulACLToken_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("consul_acl_token.test", "description", "test"),
 					resource.TestCheckResourceAttr("consul_acl_token.test", "policies.#", "1"),
 					resource.TestCheckResourceAttr("consul_acl_token.test", "policies.1785148924", "test"),
-					resource.TestCheckResourceAttr("consul_acl_token.test", "local", "false"),
+					resource.TestCheckResourceAttr("consul_acl_token.test", "local", "true"),
 				),
 			},
 			{
@@ -48,7 +48,7 @@ func TestAccConsulACLToken_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("consul_acl_token.test", "description", "test"),
 					resource.TestCheckResourceAttr("consul_acl_token.test", "policies.#", "1"),
 					resource.TestCheckResourceAttr("consul_acl_token.test", "policies.111830242", "test2"),
-					resource.TestCheckResourceAttr("consul_acl_token.test", "local", "true"),
+					resource.TestCheckResourceAttr("consul_acl_token.test", "local", "false"),
 				),
 			},
 			{
@@ -106,6 +106,7 @@ resource "consul_acl_policy" "test" {
 resource "consul_acl_token" "test" {
 	description = "test"
 	policies = ["${consul_acl_policy.test.name}"]
+	local = true
 }`
 
 const testResourceACLTokenConfigUpdate = `
@@ -119,5 +120,4 @@ resource "consul_acl_policy" "test2" {
 resource "consul_acl_token" "test" {
 	description = "test"
 	policies = ["${consul_acl_policy.test2.name}"]
-	local = true
 }`


### PR DESCRIPTION
It's more a question than a real PR.

Shouldn't the `local` attribute be set to `ForceNew`? It fails witha 500 or crashes doing `panic: interface conversion : interface {} is *schema.Set, not []interface {}` in `consul.resourceConsulACLTokenUpdate` (line 124) using the provider 2.3.0_x4 and a Consul 1.5.1 server.

```text
=== RUN   TestAccConsulACLToken_basic
--- FAIL: TestAccConsulACLToken_basic (0.06s)
    testing.go:538: Step 1 error: Error applying: 1 error occurred:
                * consul_acl_token.test: 1 error occurred:
                * consul_acl_token.test: error updating ACL token "d56b4d5f-ed65-3ed4-2064-94935b5bf129": Unexpected response code: 500 (cannot toggle local mode of d56b4d5f-ed65-3ed4-2064-94935b5bf129)
```

Cheers,