### PR TITLE
Update tests for Consul 1.5.2

### DIFF
--- a/consul/data_source_consul_service_health_test.go
+++ b/consul/data_source_consul_service_health_test.go
@@ -37,7 +37,8 @@ func TestAccDataConsulServiceHealth(t *testing.T) {
 					testAccCheckDataSourceValue("data.consul_service_health.consul", "results.0.service.0.tags.#", "0"),
 					testAccCheckDataSourceValue("data.consul_service_health.consul", "results.0.service.0.address", ""),
 					testAccCheckDataSourceValue("data.consul_service_health.consul", "results.0.service.0.port", "8300"),
-					testAccCheckDataSourceValue("data.consul_service_health.consul", "results.0.service.0.meta.%", "0"),
+					// The meta field contains data since Consul 1.5.2
+					testAccCheckDataSourceValue("data.consul_service_health.consul", "results.0.service.0.meta.%", "<any>"),
 
 					testAccCheckDataSourceValue("data.consul_service_health.consul", "results.0.checks.#", "1"),
 


### PR DESCRIPTION
Since https://github.com/hashicorp/consul/commit/4eb73973b6e53336fd505dc727ac84c1f7e78872
Consul store additional information in its service metadata field.