### PR TITLE
Use service_id instead of name when registering health-checks

### DIFF
--- a/consul/resource_consul_service.go
+++ b/consul/resource_consul_service.go
@@ -515,7 +515,7 @@ func retrieveService(client *consulapi.Client, name string, ident string, node s
 	return nil, fmt.Errorf("Failed to retrieve service: '%s', services: %v", name, len(services))
 }
 
-func parseChecks(node string, id string, d *schema.ResourceData) ([]*consulapi.HealthCheck, error) {
+func parseChecks(node string, serviceID string, d *schema.ResourceData) ([]*consulapi.HealthCheck, error) {
 	// Get health checks definition
 	checks := d.Get("check").([]interface{})
 	s := []*consulapi.HealthCheck{}
@@ -576,7 +576,7 @@ func parseChecks(node string, id string, d *schema.ResourceData) ([]*consulapi.H
 
 		s[i] = &consulapi.HealthCheck{
 			Node:       node,
-			ServiceID:  id,
+			ServiceID:  serviceID,
 			CheckID:    check["check_id"].(string),
 			Name:       check["name"].(string),
 			Notes:      check["notes"].(string),

--- a/consul/resource_consul_service.go
+++ b/consul/resource_consul_service.go
@@ -244,7 +244,7 @@ func resourceConsulServiceCreate(d *schema.ResourceData, meta interface{}) error
 		registration.Service.Tags = s
 	}
 
-	checks, err := parseChecks(node, name, d)
+	checks, err := parseChecks(node, ident, d)
 	if err != nil {
 		return fmt.Errorf("Failed to fetch health-checks: %v", err)
 	}
@@ -324,7 +324,7 @@ func resourceConsulServiceUpdate(d *schema.ResourceData, meta interface{}) error
 		registration.Service.Tags = s
 	}
 
-	checks, err := parseChecks(node, name, d)
+	checks, err := parseChecks(node, registration.Service.ID, d)
 	if err != nil {
 		return fmt.Errorf("Failed to fetch health-checks: %v", err)
 	}
@@ -504,7 +504,7 @@ func retrieveService(client *consulapi.Client, name string, ident string, node s
 			// Filter the checks that correspond to this specific service instance
 			s.Checks = make([]*consulapi.HealthCheck, 0)
 			for _, h := range healthChecks {
-				if h.Node == node {
+				if h.Node == node && h.ServiceID == ident {
 					s.Checks = append(s.Checks, h)
 				}
 			}
@@ -515,7 +515,7 @@ func retrieveService(client *consulapi.Client, name string, ident string, node s
 	return nil, fmt.Errorf("Failed to retrieve service: '%s', services: %v", name, len(services))
 }
 
-func parseChecks(node string, name string, d *schema.ResourceData) ([]*consulapi.HealthCheck, error) {
+func parseChecks(node string, id string, d *schema.ResourceData) ([]*consulapi.HealthCheck, error) {
 	// Get health checks definition
 	checks := d.Get("check").([]interface{})
 	s := []*consulapi.HealthCheck{}
@@ -576,7 +576,7 @@ func parseChecks(node string, name string, d *schema.ResourceData) ([]*consulapi
 
 		s[i] = &consulapi.HealthCheck{
 			Node:       node,
-			ServiceID:  name,
+			ServiceID:  id,
 			CheckID:    check["check_id"].(string),
 			Name:       check["name"].(string),
 			Notes:      check["notes"].(string),

--- a/consul/resource_consul_service_test.go
+++ b/consul/resource_consul_service_test.go
@@ -148,6 +148,14 @@ func TestAccConsulServiceCheck(t *testing.T) {
 					resource.TestCheckResourceAttr("consul_service.no-deregister", "check.0.deregister_critical_service_after", "30s"),
 				),
 			},
+			resource.TestStep{
+				Config: testAccConsulServiceCheckID,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_service.example", "name", "example"),
+					resource.TestCheckResourceAttr("consul_service.example", "port", "80"),
+					resource.TestCheckResourceAttr("consul_service.example", "check.#", "1"),
+				),
+			},
 		},
 	})
 }
@@ -319,6 +327,32 @@ resource "consul_service" "no-deregister" {
 		interval = "5s"
 		timeout = "1s"
 	}
+}
+`
+
+const testAccConsulServiceCheckID = `
+resource "consul_service" "example" {
+  name       = "example"
+  service_id = "service_id"
+  node       = consul_node.example.name
+  port       = 80
+
+  check {
+    check_id                          = "service:example"
+    name                              = "Example health check"
+    status                            = "passing"
+    http                              = "https://www.hashicorptest.com"
+    tls_skip_verify                   = false
+    method                            = "PUT"
+    interval                          = "5s"
+    timeout                           = "1s"
+    deregister_critical_service_after = "30s"
+  }
+}
+
+resource "consul_node" "example" {
+name    = "example"
+address = "www.example.com"
 }
 `
 

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,7 @@ github.com/hashicorp/consul v1.5.0 h1:GPtcwUGw5kjoSIF7NpDHmwHEM17ufGn1ezKQSutBMh
 github.com/hashicorp/consul v1.5.0/go.mod h1:7rvUESOLul7V9uCo5TNZ64jzf9W5Fcy/xf/TxtOT0xQ=
 github.com/hashicorp/consul/api v1.1.0 h1:BNQPM9ytxj6jbjjdRPioQ94T6YXriSopn0i8COv6SRA=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
+github.com/hashicorp/consul/sdk v0.1.1 h1:LnuDWGNsoajlhGyHJvuWW6FVqRl8JOTPqS6CPTsYjhY=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -243,6 +244,7 @@ github.com/hashicorp/go-slug v0.3.0 h1:L0c+AvH/J64iMNF4VqRaRku2DMTEuHioPVS7kMjWI
 github.com/hashicorp/go-slug v0.3.0/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86 h1:7YOlAIO2YWnJZkQp7B5eFykaIY7C9JndqAFQyVV5BhM=
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
+github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-tfe v0.3.16 h1:GS2yv580p0co4j3FBVaC6Zahd9mxdCGehhJ0qqzFMH0=
@@ -273,6 +275,7 @@ github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0m
 github.com/hashicorp/mdns v1.0.1/go.mod h1:4gW7WsVCke5TE7EPeYliwHlRUyBtfCwuFwuMg2DmyNY=
 github.com/hashicorp/memberlist v0.1.0 h1:qSsCiC0WYD39lbSitKNt40e30uorm2Ss/d4JGU1hzH8=
 github.com/hashicorp/memberlist v0.1.0/go.mod h1:ncdBp14cuox2iFOq3kDiquKU6fqsTBc3W6JvZwjxxsE=
+github.com/hashicorp/memberlist v0.1.3 h1:EmmoJme1matNzb+hMpDuR/0sbJSUisxyqBGG676r31M=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/net-rpc-msgpackrpc v0.0.0-20151116020338-a14192a58a69/go.mod h1:/z+jUGRBlwVpUZfjute9jWaF6/HuhjuFQuL1YXzVD1Q=
 github.com/hashicorp/raft v1.0.1-0.20190409200437-d9fe23f7d472/go.mod h1:DVSAWItjLjTOkVbSpWQ0j0kUADIvDaCtBxIcbNAQLkI=
@@ -354,6 +357,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.0.8 h1:Zi8HNpze3NeRWH1PQV6O71YcvJRQ6j0lORO6DAEmAAI=
 github.com/miekg/dns v1.0.8/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miekg/dns v1.0.14 h1:9jZdLNd/P4+SfEJ0TNyxYpsK8N4GtfylBLqtbYN1sbA=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0 h1:iGBIsUe3+HZ/AD/Vd7DErOt5sU9fa8Uj7A2s1aggv1Y=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -420,6 +424,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/pkg/errors v0.0.0-20170505043639-c605e284fe17 h1:chPfVn+gpAM5CTpTyVU9j8J+xgRGwmoDlNDLjKnJiYo=
 github.com/pkg/errors v0.0.0-20170505043639-c605e284fe17/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
When we register 2 services with same name but different service_id the registrations fails with 500 code error:

2 error(s) occurred:

* consul_service.proxy_http: 1 error(s) occurred:
* consul_service.proxy_http: Failed to register service (dc: ''): Unexpected response code: 500 (rpc error making call: Unknown service 'proxy' for check 'proxy-http-check')

* consul_service.proxy_socks: 1 error(s) occurred:
* consul_service.proxy_socks: Failed to register service (dc: ''): Unexpected response code: 500 (rpc error making call: Unknown service 'proxy' for check 'proxy-socks-check')

This PR fix this issue and makes the correct check service association with service_id instead of service name.

BR