### PR TITLE
Mark consul_service.check.status as computed

### DIFF
--- a/consul/resource_consul_service.go
+++ b/consul/resource_consul_service.go
@@ -120,7 +120,7 @@ func resourceConsulService() *schema.Resource {
 						"status": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "critical",
+							Computed: true,
 						},
 						"tcp": {
 							Type:     schema.TypeString,

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -110,8 +110,7 @@ The following attributes are available for each health-check:
   if not set.
 * `name` - (Required) The name of the health-check.
 * `notes` - (Optional, string) An opaque field meant to hold human readable text.
-* `status` - (Optional, string) The initial health-check status. Defaults
-  to `critical`.
+* `status` - (Optional, string) The initial health-check status.
 * `tcp` - (Optional, string) The TCP address and port to connect to for a TCP check.
 * `http` - (Optional, string) The HTTP endpoint to call for an HTTP check.
 * `header` - (Optional, set of headers) The headers to send for an HTTP check.
@@ -123,8 +122,9 @@ The following attributes are available for each health-check:
 * `interval` - (Required, string) The interval to wait between each health-check
   invocation.
 * `timeout` - (Required, string) The timeout value for HTTP checks.
-* `deregister_critical_service_after` - (Required, string) The time after which
+* `deregister_critical_service_after` - (Optional, string) The time after which
   the service is automatically deregistered when in the `critical` state.
+  Defaults to `30s`.
 
 Each `header` must have the following attributes:
 * `name` - (Required, string) The name of the header.


### PR DESCRIPTION
This value changes when a service goes from "passing" to "critical" or
"warning" so it needs to be set as Computed or Terraform will
constantly create plans to set it back to the config value.