### PR TITLE
Add meta attribute in the consul_service datasource

### DIFF
--- a/consul/data_source_consul_service.go
+++ b/consul/data_source_consul_service.go
@@ -24,6 +24,7 @@ const (
 	catalogServiceServiceName              = "name"
 	catalogServiceServicePort              = "port"
 	catalogServiceServiceTags              = "tags"
+	catalogServiceServiceMeta              = "meta"
 	catalogServiceTaggedAddresses          = "tagged_addresses"
 
 	// Filters
@@ -111,6 +112,10 @@ func dataSourceConsulService() *schema.Resource {
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						catalogServiceServiceMeta: {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
 						catalogServiceTaggedAddresses: {
 							Type:     schema.TypeMap,
 							Computed: true,
@@ -182,6 +187,7 @@ func dataSourceConsulServiceRead(d *schema.ResourceData, meta interface{}) error
 		m[catalogServiceServicePort] = fmt.Sprintf("%d", service.ServicePort)
 		sort.Strings(service.ServiceTags)
 		m[catalogServiceServiceTags] = service.ServiceTags
+		m[catalogServiceServiceMeta] = service.ServiceMeta
 		m[catalogServiceTaggedAddresses] = service.TaggedAddresses
 
 		l = append(l, m)

--- a/consul/data_source_consul_service_test.go
+++ b/consul/data_source_consul_service_test.go
@@ -55,6 +55,7 @@ func TestAccDataConsulService_filtered(t *testing.T) {
 					testAccCheckDataSourceValue("data.consul_service.read_f", "service.0.node_name", "foobar_dummy"),
 					testAccCheckDataSourceValue("data.consul_service.read_f", "service.0.port", "<any>"),
 					testAccCheckDataSourceValue("data.consul_service.read_f", "service.0.tags.#", "2"),
+					testAccCheckDataSourceValue("data.consul_service.read_f", "service.0.meta.test", "test"),
 				),
 			},
 		},
@@ -114,6 +115,9 @@ resource "consul_service" "service2" {
 	name       = "redis"
 	port       = 8000
 	tags       = ["master", "v1"]
+	meta       = {
+		test  = "test"
+	}
 }
 
 data "consul_service" "read_f" {

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -108,3 +108,5 @@ The following is a list of the per-node `service` attributes:
   List of explicit LAN and WAN IP addresses for the agent.
 * [`tags`](https://www.consul.io/docs/agent/http/catalog.html#ServiceTags) -
   List of tags for the service.
+* [`meta`](https://www.consul.io/docs/agent/http/catalog.html#Meta) - Service meta
+  data tag information, if any.


### PR DESCRIPTION
Implementing the changes described in Issue https://github.com/terraform-providers/terraform-provider-consul/issues/132, i.e. adding the ability to retrieve metadata using a service data source.