### PR TITLE
config.go properly sets TLS configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 2.6.1 (Unreleased)
+
+BUG FIXES:
+
+* The `CONSUL_CLIENT_CERT`, `CONSUL_CLIENT_KEY`, `CONSUL_CACERT` and `CONSUL_CAPATH` are now used to the set the TLS configuration of the provider.
+
 ## 2.6.0 (October 25, 2019)
 
 NEW FEATURES:

--- a/consul/config.go
+++ b/consul/config.go
@@ -35,20 +35,27 @@ func (c *Config) Client() (*consulapi.Client, error) {
 		config.Scheme = c.Scheme
 	}
 
-	tlsConfig := consulapi.TLSConfig{}
-	tlsConfig.CAFile = c.CAFile
-	tlsConfig.CertFile = c.CertFile
-	tlsConfig.KeyFile = c.KeyFile
-	tlsConfig.CAPath = c.CAPath
+	if c.CAFile != "" {
+		config.TLSConfig.CAFile = c.CAFile
+	}
+	if c.CertFile != "" {
+		config.TLSConfig.CertFile = c.CertFile
+	}
+	if c.KeyFile != "" {
+		config.TLSConfig.KeyFile = c.KeyFile
+	}
+	if c.CAPath != "" {
+		config.TLSConfig.CAPath = c.CAPath
+	}
 	if c.InsecureHttps {
 		if config.Scheme != "https" {
 			return nil, fmt.Errorf("insecure_https is meant to be used when scheme is https")
 		}
-		tlsConfig.InsecureSkipVerify = c.InsecureHttps
+		config.TLSConfig.InsecureSkipVerify = c.InsecureHttps
 	}
 
 	var err error
-	config.HttpClient, err = consulapi.NewHttpClient(config.Transport, tlsConfig)
+	config.HttpClient, err = consulapi.NewHttpClient(config.Transport, config.TLSConfig)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create http client: %s", err)
 	}
@@ -72,7 +79,7 @@ func (c *Config) Client() (*consulapi.Client, error) {
 	client, err := consulapi.NewClient(config)
 
 	log.Printf("[INFO] Consul Client configured with address: '%s', scheme: '%s', datacenter: '%s'"+
-		", insecure_https: '%t'", config.Address, config.Scheme, config.Datacenter, tlsConfig.InsecureSkipVerify)
+		", insecure_https: '%t'", config.Address, config.Scheme, config.Datacenter, config.TLSConfig.InsecureSkipVerify)
 	if err != nil {
 		return nil, err
 	}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -64,5 +64,5 @@ The following arguments are supported:
 
 ## Environment Variables
 
-All environment variables prefixed with `CONSUL_HTTP` listed in the [Consul environment variables](https://www.consul.io/docs/commands/index.html#environment-variables)
+All environment variables listed in the [Consul environment variables](https://www.consul.io/docs/commands/index.html#environment-variables)
 documentation are supported by the Terraform provider.


### PR DESCRIPTION
This change allows the Consul provider to leverage the same Consul client environment variables for setting TLS settings.

The following configuration with the current provider ignores the environment variables whereas the backend respects them.

```
CONSUL_CLIENT_CERT="/path/to/cert"
CONSUL_CLIENT_KEY="/path/to/key"
CONSUL_CACERT="/path/to/cafile"
CONSUL_CAPATH="/path/to/capath"

terraform {
  backend "consul" {
    path = "terraform/state"
    scheme = "https"
  }
}

provider "consul" {
  scheme = "https"
}
```

This change corrects this behavior and brings the provider in line with the behavior of the remote backend and Consul cli.