### PR TITLE
Run acceptance tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ install:
 # See: https://github.com/golang/go/issues/12933
 - bash scripts/gogetcookie.sh
 
-env:
-- CONSUL_HTTP_ADDR=http://localhost:8500
-- CONSUL_HTTP_TOKEN=master-token
-
 script:
 - make test
 - docker run --rm
@@ -38,4 +34,4 @@ matrix:
   allow_failures:
   - go: tip
 env:
-  - GOFLAGS=-mod=vendor GO111MODULE=on
+  - GOFLAGS=-mod=vendor GO111MODULE=on CONSUL_HTTP_TOKEN=master-token CONSUL_HTTP_ADDR=http://localhost:8500

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ env:
 
 script:
 - make test
-- docker run --rm \
-             -d \
-             --name consul-test \
-             -v $PWD/consul_test.hcl:/consul_test.hcl:ro \
-             -p 8500:8500 \
+- docker run --rm
+             -d
+             --name consul-test
+             -v $PWD/consul_test.hcl:/consul_test.hcl:ro
+             -p 8500:8500
              consul:latest consul agent -dev -config-file consul_test.hcl -client=0.0.0.0
 - make testacc
 - docker stop consul-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,20 @@ install:
 # See: https://github.com/golang/go/issues/12933
 - bash scripts/gogetcookie.sh
 
+env:
+- CONSUL_HTTP_ADDR=http://localhost:8500
+- CONSUL_HTTP_TOKEN=master-token
+
 script:
 - make test
+- docker run --rm \
+             -d \
+             --name consul-test \
+             -v $PWD/consul_test.hcl:/consul_test.hcl:ro \
+             -p 8500:8500 \
+             consul:latest consul agent -dev -config-file consul_test.hcl -client=0.0.0.0
+- make testacc
+- docker stop consul-test
 - make vet
 - make website-test
 


### PR DESCRIPTION
This is not possible for others providers since they require external
resources but we don't have this issue. While this will slow the CI a
bit it should help first time contributors and speed-up the review
process.