### PR TITLE
website: Move guides to be ingressed by the Terraform Registry

### DIFF
--- a/website/consul.erb
+++ b/website/consul.erb
@@ -11,7 +11,7 @@
         </li>
 
         <li<%= sidebar_current("docs-consul-upgrading") %>>
-          <a href="/docs/providers/consul/upgrading.html">Upgrading</a>
+          <a href="/docs/providers/consul/guides/upgrading.html">Upgrading</a>
         </li>
 
         <li<%= sidebar_current("docs-consul-data-source") %>>

--- a/website/docs/d/agent_self.html.markdown
+++ b/website/docs/d/agent_self.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # consul_agent_self
 
 ~> **Warning:** The `consul_agent_self` resource has been deprecated and will be removed
-from a future release of the provider. Read the [upgrade instructions](/docs/providers/consul/upgrading.html#deprecation-of-consul_agent_self) for more information.
+from a future release of the provider. Read the [upgrade instructions](/docs/providers/consul/guides/upgrading.html#deprecation-of-consul_agent_self) for more information.
 
 
 The `consul_agent_self` data source returns

--- a/website/docs/guides/upgrading.html.markdown
+++ b/website/docs/guides/upgrading.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "consul"
-page_title: "Provider: Consul - Upgrading"
+page_title: "Upgrading"
 sidebar_current: "docs-consul-upgrading"
 description: |-
   Detailed guidelines for upgrading between versions of the Consul Terraform Provider.
@@ -133,4 +133,4 @@ View migration instructions [here][migrate_service].
 continue to work, but in the long term it may be deprecated and removed. This is to present
 a more consistent and intuitive naming convention for the resources.
 
-[migrate_service]: /docs/providers/consul/upgrading.html#migrating-to-consul_service-or-consul_node-resources "Migrate to consul_service or consul_node"
+[migrate_service]: /docs/providers/consul/guides/upgrading.html#migrating-to-consul_service-or-consul_node-resources "Migrate to consul_service or consul_node"

--- a/website/docs/r/agent_service.html.markdown
+++ b/website/docs/r/agent_service.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # consul_agent_service
 
 !> The `consul_agent_service` resource has been deprecated in version 2.0.0 of the provider
-and will be removed in a future release. Please read the [upgrade guide](/docs/providers/consul/upgrading.html#deprecation-of-consul_agent_service)
+and will be removed in a future release. Please read the [upgrade guide](/docs/providers/consul/guides/upgrading.html#deprecation-of-consul_agent_service)
 for more information.
 
 Provides access to the agent service data in Consul. This can be used to

--- a/website/docs/r/catalog_entry.html.markdown
+++ b/website/docs/r/catalog_entry.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # consul_catalog_entry
 
 !> The `consul_catalog_entry` resource has been deprecated in version 2.0.0 of the provider
-and will be removed in a future release. Please read the [upgrade guide](/docs/providers/consul/upgrading.html#deprecation-of-consul_catalog_entry)
+and will be removed in a future release. Please read the [upgrade guide](/docs/providers/consul/guides/upgrading.html#deprecation-of-consul_catalog_entry)
 for more information.
 
 Registers a node or service with the [Consul Catalog](https://www.consul.io/docs/agent/http/catalog.html#catalog_register).


### PR DESCRIPTION
We will soon be displaying documentation for this provider both on [terraform.io](https://www.terraform.io/docs/providers/index.html) and on [the Terraform Registry](https://registry.terraform.io/providers).

This PR moves guide documentation files to a dedicated subdirectory for guides. This enables the Registry to display these files distinctly from resources and data sources in the navigation tree. Links to these files in other documentation files are also updated to the new path.

For more information about how documentation is rendered on the Terraform Registry, please see this reference: [Terraform Registry - Provider Documentation](https://www.terraform.io/docs/registry/providers/docs.html).