### PR TITLE
Improve plans for consul_keys

### DIFF
--- a/consul/resource_consul_keys.go
+++ b/consul/resource_consul_keys.go
@@ -48,6 +48,7 @@ func resourceConsulKeys() *schema.Resource {
 						"name": {
 							Type:       schema.TypeString,
 							Optional:   true,
+							Default:    "",
 							Deprecated: "Using consul_keys resource to *read* is deprecated; please use consul_keys data source instead",
 						},
 
@@ -71,6 +72,7 @@ func resourceConsulKeys() *schema.Resource {
 						"default": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 
 						"delete": {


### PR DESCRIPTION
The plan for for consul_keys resource always showed all unchanged keys
as being removed and added back making the diff hard to read:

```
  # consul_keys.product_vars will be updated in-place
  ~ resource "consul_keys" "product_vars" {
        datacenter = "dc1"
        id         = "consul"
      ~ var        = {} -> (known after apply)

      - key {
          - delete = true -> null
          - flags  = 0 -> null
          - path   = "products/xxx/env_vars/FOOBAR" -> null
          - value  = "/password" -> null
        }
      - key {
          - delete = true -> null
          - flags  = 0 -> null
          - path   = "products/xxx/env_vars/PASSWORD_PATH" -> null
          - value  = "/password" -> null
        }
      - key {
          - delete = true -> null
          - flags  = 0 -> null
          - path   = "products/xxxx/env_vars/INVITATION_PATH" -> null
          - value  = "/invitation_old" -> null
        }
      + key {
          + delete = true
          + flags  = 0
          + path   = "products/xxx/env_vars/FOOBAR"
          + value  = "/password"
        }
      + key {
          + delete = true
          + flags  = 0
          + path   = "products/xxx/env_vars/PASSWORD_PATH"
          + value  = "/password"
        }
    }
```

Only the specific keys changed will now have markers:

```
  # consul_keys.product_vars will be updated in-place
  ~ resource "consul_keys" "product_vars" {
        datacenter = "dc1"
        id         = "consul"
      ~ var        = {} -> (known after apply)

        key {
            delete = true
            flags  = 0
            path   = "products/xxx/env_vars/FOOBAR"
            value  = "/password"
        }
        key {
            delete = true
            flags  = 0
            path   = "products/xxx/env_vars/PASSWORD_PATH"
            value  = "/password"
        }
      - key {
          - delete = true -> null
          - flags  = 0 -> null
          - path   = "products/xxxx/env_vars/INVITATION_PATH" -> null
          - value  = "/invitation_old" -> null
        }
    }
```
Closes https://github.com/terraform-providers/terraform-provider-consul/issues/162