### PR TITLE
Fix error checking in ACL resources

### DIFF
--- a/consul/resource_consul_acl_policy.go
+++ b/consul/resource_consul_acl_policy.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -84,9 +85,12 @@ func resourceConsulACLPolicyRead(d *schema.ResourceData, meta interface{}) error
 
 	aclPolicy, _, err := client.ACL().PolicyRead(id, nil)
 	if err != nil {
-		log.Printf("[WARN] ACL policy not found, removing from state")
-		d.SetId("")
-		return nil
+		if strings.Contains(err.Error(), "ACL not found") {
+			log.Printf("[INFO] ACL policy not found, removing from state")
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Failed to read policy '%s': %v", id, err)
 	}
 
 	log.Printf("[DEBUG] Read ACL policy %q", id)

--- a/consul/resource_consul_acl_token.go
+++ b/consul/resource_consul_acl_token.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -93,9 +94,12 @@ func resourceConsulACLTokenRead(d *schema.ResourceData, meta interface{}) error 
 
 	aclToken, _, err := client.ACL().TokenRead(id, nil)
 	if err != nil {
-		log.Printf("[WARN] ACL token not found, removing from state")
-		d.SetId("")
-		return nil
+		if strings.Contains(err.Error(), "ACL not found") {
+			log.Printf("[WARN] ACL token not found, removing from state")
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Failed to read token '%s': %v", id, err)
 	}
 
 	log.Printf("[DEBUG] Read ACL token %q", id)

--- a/consul/resource_consul_acl_token_policy_attachment.go
+++ b/consul/resource_consul_acl_token_policy_attachment.go
@@ -85,9 +85,12 @@ func resourceConsulACLTokenPolicyAttachmentRead(d *schema.ResourceData, meta int
 
 	aclToken, _, err := client.ACL().TokenRead(tokenID, nil)
 	if err != nil {
-		log.Printf("[WARN] ACL token not found, removing from state")
-		d.SetId("")
-		return nil
+		if strings.Contains(err.Error(), "ACL not found") {
+			log.Printf("[WARN] ACL token not found, removing from state")
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Failed to read token '%s': %v", id, err)
 	}
 
 	log.Printf("[DEBUG] Read ACL token %q", tokenID)


### PR DESCRIPTION
Failing to read a policy or a token from the server does not necessarily mean
that the policy has been removed, the network can be down, the correct
datacenter may not be reachable etc. We must be conservative when
removing resources from the state and only create a new one if it's
actually needed.