### PR TITLE
consul_key_prefix: Fix update of subkey blocks.

### DIFF
--- a/consul/resource_consul_key_prefix.go
+++ b/consul/resource_consul_key_prefix.go
@@ -294,12 +294,6 @@ func resourceConsulKeyPrefixRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	// If not keys under the prefix => The prefix does not exist.
-	if len(pairs) == 0 {
-		d.SetId("")
-		return nil
-	}
-
 	subKeys := make(map[string]string)
 	if subKeySet, ok := d.GetOk("subkey"); ok {
 		subkeyList := subKeySet.(*schema.Set).List()

--- a/consul/resource_consul_key_prefix_test.go
+++ b/consul/resource_consul_key_prefix_test.go
@@ -22,6 +22,9 @@ func TestAccConsulKeyPrefix_basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
+				Config: testAccConsulKeyPrefixNoKeys,
+			},
+			{
 				Config: testAccConsulKeyPrefixConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConsulKeyPrefixKeyValue("cheese", "chevre", 0),
@@ -271,6 +274,12 @@ func testAccCheckConsulKeyPrefixKeyValue(name, value string, flags uint64) resou
 		return nil
 	}
 }
+
+const testAccConsulKeyPrefixNoKeys = `
+resource "consul_key_prefix" "app" {
+	datacenter = "dc1"
+	path_prefix = "prefix_test/"
+}`
 
 const testAccConsulKeyPrefixConfig = `
 resource "consul_key_prefix" "app" {


### PR DESCRIPTION
# Description

Resource ``consul_key_prefix``: Update of subkey blocks does not work properly.

In the first place, we find out that if one or more keys (created with ``subkey`` block) are manually removed in Consul, the provider does not detect it and doesn't recreate the missing key(s) (even if there's not key at all under this prefix).

When writing the fix for that, I find out that even adding new subkey blocks does not work properly.
It will add the new key but remove the existing ones (because of this [`continue`](https://github.com/terraform-providers/terraform-provider-consul/blob/aab0d40ed795ff184511514e17ff111397bef736/consul/resource_consul_key_prefix.go#L258) which continues the wrong for loop)

Then the provider will not detect that the mistakenly deleted keys are missing.

# How to reproduce


* I start a Consul server in a Docker container with

```bash
$ docker run --rm -p 8500:8500 consul
```

  With that the default configuration of the provider is working.


* Create a test file with a ``consul_key_prefix`` resource with one ``subkey``

```hcl
resource "consul_key_prefix" "test" {
  path_prefix = "test/"

  subkey {
    path  = "key1"
    value = "plop"
  }
}
```

* Apply it

```bash
$ terraform init
[...]
$ terraform apply
[...]
Terraform will perform the following actions:

  # consul_key_prefix.test will be created
  + resource "consul_key_prefix" "test" {
      + datacenter  = (known after apply)
      + id          = (known after apply)
      + path_prefix = "test/"

      + subkey {
          + flags = 0
          + path  = "key1"
          + value = "plop"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
[...]
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

* Check keys in Consul:

```bash
$ curl "localhost:8500/v1/kv/test?recurse=true&keys=true"
[
    "test/key1"
]
```
* Add a second key:

```hcl
resource "consul_key_prefix" "test" {
  path_prefix = "test/"

  subkey {
    path  = "key1"
    value = "plop"
  }

  subkey {
    path  = "key2"
    value = "plop"
  }
}
```
* And apply

```bash
$ terraform apply
consul_key_prefix.test: Refreshing state... [id=test/]
[...]
  # consul_key_prefix.test will be updated in-place
  ~ resource "consul_key_prefix" "test" {
        datacenter  = "dc1"
        id          = "test/"
        path_prefix = "test/"
        subkeys     = {}

        subkey {
            flags = 0
            path  = "key1"
            value = "plop"
        }
      + subkey {
          + flags = 0
          + path  = "key2"
          + value = "plop"
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
[...]
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

The plan is OK but it does not what the plan says, here are the keys in Consul:

```bash
$ curl "localhost:8500/v1/kv/test?recurse=true&keys=true"
[
    "test/key2"
]
```

It created the second key but removed the first one.
Further plans will not detect the missing key:

```
$ terraform plan
[...]
consul_key_prefix.test: Refreshing state... [id=test/]

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.
```