### PR TITLE
Fix typo in documentation: s/gpg_key/pgp_key/

### DIFF
--- a/website/docs/d/acl_token_secret_id.html.markdown
+++ b/website/docs/d/acl_token_secret_id.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # consul_acl_token_secret_id
 
 ~> **Warning:** When using this is resource, the ACL Token secret ID will be
-written to the Terraform state. It is strongly recommended to use the `gpg_key`
+written to the Terraform state. It is strongly recommended to use the `pgp_key`
 attribute and to make sure the remote state has strong access controls before
 using this resource.
 
@@ -24,24 +24,24 @@ If you want to get other attributes of the Consul ACL token, please use the
 
 ```hcl
 resource "consul_acl_policy" "test" {
-	name = "test"
-	rules = "node \"\" { policy = \"read\" }"
+	name        = "test"
+	rules       = "node \"\" { policy = \"read\" }"
 	datacenters = [ "dc1" ]
 }
 
 resource "consul_acl_token" "test" {
 	description = "test"
-	policies = ["${consul_acl_policy.test.name}"]
-	local = true
+	policies    = [consul_acl_policy.test.name]
+	local       = true
 }
 
 data "consul_acl_token_secret_id" "read" {
-    accessor_id = "${consul_acl_token.test.id}"
-	gpg_key     = "keybase:my_username"
+    accessor_id = consul_acl_token.test.id
+	pgp_key     = "keybase:my_username"
 }
 
 output "consul_acl_token_secret_id" {
-  value = "${data.consul_acl_token.read.encrypted_secret_id}"
+  value = data.consul_acl_token.read.encrypted_secret_id
 }
 ```
 
@@ -51,7 +51,7 @@ output "consul_acl_token_secret_id" {
 The following arguments are supported:
 
 * `accessor_id` - (Required) The accessor ID of the ACL token.
-* `gpg_key` - (Optional) Either a base-64 encoded PGP public key, or a keybase
+* `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a keybase
   username in the form `keybase:some_person_that_exists`. **If you do not set this
   argument, the token secret ID will be written as plain text in the Terraform
   state.**
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `secret_id` - The secret ID of the ACL token if `gpg_key` has not been set.
-* `encrypted_secret_id` - The encrypted secret ID of the ACL token if `gpg_key`
+* `secret_id` - The secret ID of the ACL token if `pgp_key` has not been set.
+* `encrypted_secret_id` - The encrypted secret ID of the ACL token if `pgp_key`
   has been set. You can decrypt the secret by using the command line, for example
   with: `terraform output encrypted_secret | base64 --decode | keybase pgp decrypt`.


### PR DESCRIPTION
The documentation mentions `gpg_key` when the attribute is `pgp_key`