### PR TITLE
Fix typo in consul_service documentation

### DIFF
--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -44,7 +44,7 @@ resource "consul_service" "google" {
 }
 ```
 
-Register an health-check:
+Register a health-check:
 
 ```hcl
 resource "consul_service" "redis" {


### PR DESCRIPTION
"Register an health-check" to "Register a health-check"