### PR TITLE
Allow creating tokens with pregenerated secret_ids

### DIFF
--- a/consul/resource_consul_acl_token.go
+++ b/consul/resource_consul_acl_token.go
@@ -20,12 +20,20 @@ func resourceConsulACLToken() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"secret_id": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Computed:    true,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "The token secret id.",
+			},
 			"accessor_id": {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Computed:    true,
 				Optional:    true,
-				Description: "The token id.",
+				Description: "The token accessor id.",
 			},
 			"description": {
 				Type:        schema.TypeString,
@@ -187,6 +195,7 @@ func resourceConsulACLTokenDelete(d *schema.ResourceData, meta interface{}) erro
 func getToken(d *schema.ResourceData) *consulapi.ACLToken {
 	aclToken := &consulapi.ACLToken{
 		AccessorID:  d.Get("accessor_id").(string),
+		SecretID:    d.Get("secret_id").(string),
 		Description: d.Get("description").(string),
 		Local:       d.Get("local").(bool),
 	}


### PR DESCRIPTION
Hi,

I am aware of how contentious this is due to sensitive data ending up in the state file, so I am just testing the water.

In a scenario where token IDs are programatically generated and distributed to the Consul, Nomad and Vault nodes over an out of band channel, they can then be subsequently provisioned in Consul. Perhaps this can also be placed under a boldface warning sign as we have for consul_acl_token_secret_id, suggesting storing the state remotely?

Thanks!

