### PR TITLE
Fix datacenter handling in consul_intention

### DIFF
--- a/consul/resource_consul_config_entry_test.go
+++ b/consul/resource_consul_config_entry_test.go
@@ -114,7 +114,7 @@ func TestAccConsulConfigEntry_basic(t *testing.T) {
 			{
 				Config: testAccConsulConfigEntry_TerminatingGateway(extraConf),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("consul_config_entry.terminating_gateway", "name", "foo"),
+					resource.TestCheckResourceAttr("consul_config_entry.terminating_gateway", "name", "foo-egress"),
 					resource.TestCheckResourceAttr("consul_config_entry.terminating_gateway", "kind", "terminating-gateway"),
 					resource.TestCheckResourceAttr("consul_config_entry.terminating_gateway", "config_json", configJSONTerminatingGateway),
 				),
@@ -367,7 +367,7 @@ resource "consul_config_entry" "ingress_gateway" {
 func testAccConsulConfigEntry_TerminatingGateway(extraConf string) string {
 	return fmt.Sprintf(`
 resource "consul_config_entry" "terminating_gateway" {
-	name = "foo"
+	name = "foo-egress"
 	kind = "terminating-gateway"
 
 	config_json = jsonencode({

--- a/consul/resource_consul_intention.go
+++ b/consul/resource_consul_intention.go
@@ -72,14 +72,9 @@ func resourceConsulIntentionCreate(d *schema.ResourceData, meta interface{}) err
 	client := getClient(meta)
 	connect := client.Connect()
 
-	var dc string
-	if v, ok := d.GetOk("datacenter"); ok {
-		dc = v.(string)
-	} else {
-		var err error
-		if dc, err = getDC(d, client, meta); err != nil {
-			return err
-		}
+	dc, err := getDC(d, client, meta)
+	if err != nil {
+		return fmt.Errorf("Failed to get DC: %v", err)
 	}
 
 	wOpts := consulapi.WriteOptions{Datacenter: dc}
@@ -104,9 +99,9 @@ func resourceConsulIntentionUpdate(d *schema.ResourceData, meta interface{}) err
 	connect := client.Connect()
 
 	// Setup the operations using the datacenter
-	dc := ""
-	if _, ok := d.GetOk("datacenter"); ok {
-		dc = d.Get("datacenter").(string)
+	dc, err := getDC(d, client, meta)
+	if err != nil {
+		return fmt.Errorf("Failed to get DC: %v", err)
 	}
 	wOpts := consulapi.WriteOptions{Datacenter: dc}
 
@@ -127,9 +122,9 @@ func resourceConsulIntentionRead(d *schema.ResourceData, meta interface{}) error
 	client := getClient(meta)
 	connect := client.Connect()
 
-	var dc string
-	if v, ok := d.GetOk("datacenter"); ok {
-		dc = v.(string)
+	dc, err := getDC(d, client, meta)
+	if err != nil {
+		return fmt.Errorf("Failed to get DC: %v", err)
 	}
 
 	id := d.Id()
@@ -175,14 +170,9 @@ func resourceConsulIntentionDelete(d *schema.ResourceData, meta interface{}) err
 	connect := client.Connect()
 	id := d.Id()
 
-	var dc string
-	if v, ok := d.GetOk("datacenter"); ok {
-		dc = v.(string)
-	} else {
-		var err error
-		if dc, err = getDC(d, client, meta); err != nil {
-			return err
-		}
+	dc, err := getDC(d, client, meta)
+	if err != nil {
+		return fmt.Errorf("Failed to get DC: %v", err)
 	}
 
 	// Setup the operations using the datacenter

--- a/consul/resource_consul_intention.go
+++ b/consul/resource_consul_intention.go
@@ -140,6 +140,9 @@ func resourceConsulIntentionRead(d *schema.ResourceData, meta interface{}) error
 		return nil
 	}
 
+	if err = d.Set("datacenter", dc); err != nil {
+		return fmt.Errorf("failed to set 'datacenter': %v", err)
+	}
 	if err = d.Set("source_name", intention.SourceName); err != nil {
 		return fmt.Errorf("failed to set 'source_name': %v", err)
 	}

--- a/consul/resource_consul_intention_test.go
+++ b/consul/resource_consul_intention_test.go
@@ -20,6 +20,7 @@ func TestAccConsulIntention_basic(t *testing.T) {
 				Config: testAccConsulIntentionConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("consul_intention.example", "source_name", "api"),
+					resource.TestCheckResourceAttr("consul_intention.example", "datacenter", "nyc3"),
 					resource.TestCheckResourceAttr("consul_intention.example", "destination_name", "db"),
 					resource.TestCheckResourceAttr("consul_intention.example", "action", "allow"),
 					resource.TestCheckResourceAttr("consul_intention.example", "description", "something about example"),
@@ -32,6 +33,7 @@ func TestAccConsulIntention_basic(t *testing.T) {
 				Config:    testAccConsulIntentionConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("consul_intention.example", "source_name", "api"),
+					resource.TestCheckResourceAttr("consul_intention.example", "datacenter", "nyc3"),
 					resource.TestCheckResourceAttr("consul_intention.example", "destination_name", "db"),
 					resource.TestCheckResourceAttr("consul_intention.example", "action", "allow"),
 					resource.TestCheckResourceAttr("consul_intention.example", "description", "something about example"),
@@ -136,9 +138,39 @@ func testAccRemoveConsulIntention(t *testing.T) func() {
 	}
 }
 
+func TestAccConsulIntention_dc(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() {},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConsulIntentionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConsulIntentionDcFallback,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_intention.example", "source_name", "api"),
+					resource.TestCheckResourceAttr("consul_intention.example", "datacenter", "dc1"),
+					resource.TestCheckResourceAttr("consul_intention.example", "destination_name", "db"),
+					resource.TestCheckResourceAttr("consul_intention.example", "action", "allow"),
+				),
+			},
+			{
+				PreConfig: testAccRemoveConsulIntention(t),
+				Config:    testAccConsulIntentionConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_intention.example", "source_name", "api"),
+					resource.TestCheckResourceAttr("consul_intention.example", "datacenter", "dc1"),
+					resource.TestCheckResourceAttr("consul_intention.example", "destination_name", "db"),
+					resource.TestCheckResourceAttr("consul_intention.example", "action", "allow"),
+				),
+			},
+		},
+	})
+}
+
 const testAccConsulIntentionConfigBasic = `
 resource "consul_intention" "example" {
 	source_name      = "api"
+	datacenter       = "nyc3"
 	destination_name = "db"
 	action           = "allow"
 
@@ -166,6 +198,15 @@ resource "consul_intention" "example" {
 	destination_name      = "db"
 	destination_namespace = "ns"
 
+	action = "allow"
+}
+`
+
+const testAccConsulIntentionDcFallback = `
+resource "consul_intention" "example" {
+	source_name           = "api"
+	destination_name      = "db"
+	
 	action = "allow"
 }
 `

--- a/website/docs/r/intention.html.markdown
+++ b/website/docs/r/intention.html.markdown
@@ -75,6 +75,10 @@ The following attributes are exported:
 
 * `id` - The ID of the intention.
 * `source_name` - The source for the intention.
+* `source_namespace` - The source namespace of the intention.
 * `destination_name` - The destination for the intention.
+* `destination_namespace` - The destination namespace of the intention.
+* `action` - The intention action.
 * `description` - A description of the intention.
 * `meta` - Key/value pairs associated with the intention.
+* `datacenter` - The datacenter in which the intention is created.


### PR DESCRIPTION
This patch should resolve #213, so that the `consul_intention` resource accepts datacenter as an argument, which is already reflected in existing documentation.