### PR TITLE
Update regexp for Consul namespaces test in Community Edition

### DIFF
--- a/consul/data_source_consul_acl_auth_method_test.go
+++ b/consul/data_source_consul_acl_auth_method_test.go
@@ -50,7 +50,7 @@ func TestAccDataACLAuthMethod_namespaceCE(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceACLAuthMethodConfigNamespaceCE,
-				ExpectError: regexp.MustCompile("Namespaces is a Consul Enterprise feature"),
+				ExpectError: namespaceEnterpriseFeature,
 			},
 		},
 	})

--- a/consul/data_source_consul_acl_policy_test.go
+++ b/consul/data_source_consul_acl_policy_test.go
@@ -37,7 +37,7 @@ func TestAccDataACLPolicy_namespaceCE(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceACLPolicyNamespaceCE,
-				ExpectError: regexp.MustCompile("Namespaces is a Consul Enterprise feature"),
+				ExpectError: namespaceEnterpriseFeature,
 			},
 		},
 	})

--- a/consul/data_source_consul_acl_role_test.go
+++ b/consul/data_source_consul_acl_role_test.go
@@ -40,7 +40,7 @@ func TestAccDataACLRole_namespaceCE(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceACLRoleConfigNamespaceCE,
-				ExpectError: regexp.MustCompile("Namespaces is a Consul Enterprise feature"),
+				ExpectError: namespaceEnterpriseFeature,
 			},
 		},
 	})

--- a/consul/data_source_consul_acl_token_test.go
+++ b/consul/data_source_consul_acl_token_test.go
@@ -1,7 +1,6 @@
 package consul
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -33,7 +32,7 @@ func TestAccDataACLToken_namespaceCE(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataACLTokenConfigNamespaceCE,
-				ExpectError: regexp.MustCompile("Namespaces is a Consul Enterprise feature"),
+				ExpectError: namespaceEnterpriseFeature,
 			},
 		},
 	})

--- a/consul/data_source_consul_service_test.go
+++ b/consul/data_source_consul_service_test.go
@@ -1,7 +1,6 @@
 package consul
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -91,7 +90,7 @@ func TestAccDataConsulService_namespaceCE(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataConsulServiceNamespaceCE,
-				ExpectError: regexp.MustCompile("Namespaces is a Consul Enterprise feature"),
+				ExpectError: namespaceEnterpriseFeature,
 			},
 		},
 	})

--- a/consul/data_source_consul_services_test.go
+++ b/consul/data_source_consul_services_test.go
@@ -59,7 +59,7 @@ func TestAccDataConsulServices_namespaceCE(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataConsulServicesNamespaceCE,
-				ExpectError: regexp.MustCompile("Namespaces is a Consul Enterprise feature"),
+				ExpectError: namespaceEnterpriseFeature,
 			},
 		},
 	})

--- a/consul/resource_consul_acl_auth_method_test.go
+++ b/consul/resource_consul_acl_auth_method_test.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	consulapi "github.com/hashicorp/consul/api"
@@ -68,7 +67,7 @@ func TestAccConsulACLAuthMethod_namespaceCE(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testResourceACLAuthMethodNamespaceCE,
-				ExpectError: regexp.MustCompile("Namespaces is a Consul Enterprise feature"),
+				ExpectError: namespaceEnterpriseFeature,
 			},
 		},
 	})

--- a/consul/resource_consul_acl_binding_rule_test.go
+++ b/consul/resource_consul_acl_binding_rule_test.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	consulapi "github.com/hashicorp/consul/api"
@@ -48,7 +47,7 @@ func TestAccConsulACLBindingRule_namespaceCE(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testResourceACLBindingRuleConfig_namespaceCE,
-				ExpectError: regexp.MustCompile("Namespaces is a Consul Enterprise feature"),
+				ExpectError: namespaceEnterpriseFeature,
 			},
 		},
 	})

--- a/consul/resource_consul_acl_policy_test.go
+++ b/consul/resource_consul_acl_policy_test.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -101,7 +100,7 @@ func TestAccConsulACLPolicy_NamespaceCE(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testResourceACLPolicyNamespaceCE,
-				ExpectError: regexp.MustCompile("Namespaces is a Consul Enterprise feature"),
+				ExpectError: namespaceEnterpriseFeature,
 			},
 		},
 	})

--- a/consul/resource_consul_acl_role_test.go
+++ b/consul/resource_consul_acl_role_test.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	consulapi "github.com/hashicorp/consul/api"
@@ -83,7 +82,7 @@ func TestAccConsulACLRole_NamespaceCE(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testResourceACLRoleNamespaceCE,
-				ExpectError: regexp.MustCompile("Namespaces is a Consul Enterprise feature"),
+				ExpectError: namespaceEnterpriseFeature,
 			},
 		},
 	})

--- a/consul/resource_consul_acl_token_test.go
+++ b/consul/resource_consul_acl_token_test.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -110,7 +109,7 @@ func TestAccConsulACLToken_namespaceCE(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testResourceACLTokenConfigNamespaceCE,
-				ExpectError: regexp.MustCompile("Namespaces is a Consul Enterprise feature"),
+				ExpectError: namespaceEnterpriseFeature,
 			},
 		},
 	})

--- a/consul/resource_consul_keys_test.go
+++ b/consul/resource_consul_keys_test.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	consulapi "github.com/hashicorp/consul/api"
@@ -59,7 +58,7 @@ func TestAccConsulKeys_NamespaceCE(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccConsulKeysNamespaceCE,
-				ExpectError: regexp.MustCompile("Namespaces is a Consul Enterprise feature"),
+				ExpectError: namespaceEnterpriseFeature,
 			},
 		},
 	})

--- a/consul/resource_consul_namespace_test.go
+++ b/consul/resource_consul_namespace_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
+var namespaceEnterpriseFeature = regexp.MustCompile("Namespaces .* Consul Enterprise feature")
+
 func TestAccConsulNamespace_FailOnCommunityEdition(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { skipTestOnConsulEnterpriseEdition(t) },

--- a/consul/resource_consul_service_test.go
+++ b/consul/resource_consul_service_test.go
@@ -238,7 +238,7 @@ func TestAccConsulService_NamespaceCE(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccConsulServiceNamespaceCE,
-				ExpectError: regexp.MustCompile("Namespaces is a Consul Enterprise feature"),
+				ExpectError: namespaceEnterpriseFeature,
 			},
 		},
 	})


### PR DESCRIPTION
It changed change in Consul 1.8 from `"Namespaces is a Consul Enterprise feature"` to ``"Namespaces are a Consul Enterprise feature"`` so the regexp should match both versions.