### PR TITLE
docs: remove technical preview warning for Cluster Peering functionality

### DIFF
--- a/docs/resources/peering.md
+++ b/docs/resources/peering.md
@@ -15,8 +15,6 @@ description: |-
 
 The `cluster_peering` resource can be used to establish the peering after a peering token has been generated.
 
-~> **Cluster peering is currently in technical preview:** Functionality associated with cluster peering is subject to change. You should never use the technical preview release in secure environments or production scenarios. Features in technical preview may have performance issues, scaling issues, and limited support.
-
 The functionality described here is available only in Consul version 1.13.0 and later.
 
 ## Example Usage


### PR DESCRIPTION
Consul cluster peering is not in technical preview since Consul `v1.13.0`. Removed the related warning in the `docs/` page.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
